### PR TITLE
Changed rosidl_generator_cpp with rosidl_runtime_cpp

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -23,6 +23,7 @@ ament_export_dependencies(rcpputils)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
+ament_export_dependencies(rosidl_runtime_cpp)
 
 rosidl_generate_interfaces(
   ${PROJECT_NAME}_interfaces
@@ -39,7 +40,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "rcpputils"
   "rcutils"
   "rmw"
-  "rosidl_generator_cpp")
+  "rosidl_runtime_cpp")
 add_dependencies(${PROJECT_NAME}
   ${PROJECT_NAME}_interfaces)
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -65,7 +66,7 @@ ament_export_libraries(${PROJECT_NAME})
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
-ament_export_dependencies(rosidl_generator_cpp)
+ament_export_dependencies(rosidl_runtime_cpp)
 
 install(
   DIRECTORY include/

--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -16,13 +16,11 @@ find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_dds_common_generators REQUIRED)
-find_package(rosidl_cmake REQUIRED)
 
 ament_export_dependencies(ament_cmake_core)
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
-ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_runtime_cpp)
 
 rosidl_generate_interfaces(

--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -63,11 +63,6 @@ install(
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME})
 
-ament_export_dependencies(rcpputils)
-ament_export_dependencies(rcutils)
-ament_export_dependencies(rmw)
-ament_export_dependencies(rosidl_runtime_cpp)
-
 install(
   DIRECTORY include/
   DESTINATION include)

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -10,12 +10,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
   <buildtool_depend>rmw_dds_common_generators</buildtool_depend>
+
+  <buildtool_export_depend>rosidl_runtime_cpp</buildtool_export_depend>
 
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>
-  <depend>rosidl_generator_cpp</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -10,14 +10,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
   <buildtool_depend>rmw_dds_common_generators</buildtool_depend>
-
-  <buildtool_export_depend>rosidl_runtime_cpp</buildtool_export_depend>
 
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>
+  <depend>rosidl_runtime_cpp</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -9,10 +9,7 @@
   <author>Ivan Paunovic</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rmw_dds_common_generators</buildtool_depend>
-
-  <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <depend>rcutils</depend>
   <depend>rcpputils</depend>

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -12,6 +12,8 @@
   <buildtool_depend>rosidl_cmake</buildtool_depend>
   <buildtool_depend>rmw_dds_common_generators</buildtool_depend>
 
+  <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
+
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>


### PR DESCRIPTION
I created this PR as part of the effort to split `rosidl_generator` in two part `rosidl_generator_x` and `rosidl_runtime_x`

Header are now located in `rosidl_runtime_cpp` package not in the `rosild_generator_cpp` package.

As @dirk-thomas request in this issue https://github.com/ros2/rmw_dds_common/issues/9, `rosidl_generator_cpp` could not be a runtime dependency because it does not contain any `.so/dll/dylib`. I changed this in the `package.xml` to `<buildtool_depend>` and `buildtool_export_depend`

Signed-off-by: ahcorde <ahcorde@gmail.com>