### PR TITLE
Avoid registering generated interfaces as a rosidl_interfaces resource

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -29,7 +29,7 @@ rosidl_generate_interfaces(
   "msg/Gid.idl"
   "msg/NodeEntitiesInfo.idl"
   "msg/ParticipantEntitiesInfo.idl"
-  SKIP_GROUP_MEMBERSHIP_CHECK
+  SKIP_RESOURCE_REGISTER
 )
 
 add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
Fixes ros2/rmw_dds_common#8.
Depends on https://github.com/ros2/rosidl/pull/454.

It avoids registering the generated interfaces as an ament `roidl_interfaces` resource.
`SKIP_INSTALL` option can't be used, as `rmw_fastrtps_cpp` and `rmw_fastrtps_dynamic_cpp` need to use the generated interfaces.

See https://github.com/ros2/ros1_bridge/pull/252.