### PR TITLE
Improve test coverage

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -72,11 +72,12 @@ install(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_cmake_gmock REQUIRED)
+  find_package(osrf_testing_tools_cpp REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
   ament_add_gmock(test_graph_cache test/test_graph_cache.cpp)
   if(TARGET test_graph_cache)
-    target_link_libraries(test_graph_cache ${PROJECT_NAME}_library)
+    target_link_libraries(test_graph_cache ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools)
   endif()
 
   ament_add_gmock(test_gid_utils test/test_gid_utils.cpp)

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>osrf_testing_tools_cpp</test_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
 


### PR DESCRIPTION
Precisely what the title says. With these additions, test coverage for sources is > 90%. 

If we want to push for that final ~10%, we'll have to mock `rcutils` and `rmw` APIs.