### PR TITLE
Add function for checking QoS profile compatibility

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -33,6 +33,7 @@ rosidl_generate_interfaces(
 add_library(${PROJECT_NAME}_library SHARED
   src/gid_utils.cpp
   src/graph_cache.cpp
+  src/qos.cpp
   src/time_utils.cpp)
 
 set_target_properties(${PROJECT_NAME}_library
@@ -90,6 +91,11 @@ if(BUILD_TESTING)
   ament_add_gmock(test_gid_utils test/test_gid_utils.cpp)
   if(TARGET test_gid_utils)
     target_link_libraries(test_gid_utils ${PROJECT_NAME}_library)
+  endif()
+
+  ament_add_gmock(test_qos test/test_qos.cpp)
+  if(TARGET test_qos)
+    target_link_libraries(test_qos ${PROJECT_NAME}_library)
   endif()
 
   ament_add_gmock(test_time_utils test/test_time_utils.cpp)

--- a/rmw_dds_common/docs/FEATURES.md
+++ b/rmw_dds_common/docs/FEATURES.md
@@ -11,3 +11,4 @@ This package includes:
   - A generic [`Context`](rmw_dds_common/include/rmw_dds_common/context.hpp) type to withhold most state needed to implement [ROS nodes discovery](https://github.com/ros2/design/pull/250)
   - [Comparison utilities and some C++ operator overloads](rmw_dds_common/include/rmw_dds_common/gid_utils.hpp) for `rmw_gid_t` instances
   - [Conversion utilities](rmw_dds_common/include/rmw_dds_common/gid_utils.hpp) between `rmw_dds_common/msg/Gid` messages and `rmw_gid_t` instances
+  - A function for checking the compatibility of two QoS profiles, [`qos_profile_check_compatible`](rmw_dds_common/include/rmw_dds_common/qos.hpp)

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -45,7 +45,6 @@ namespace rmw_dds_common
  * \return `RMW_RET_OK` if the check was successful, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is `nullptr`, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `reason` is `nullptr` and  `reason_size` is not zero, or
- * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
  * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_DDS_COMMON_PUBLIC

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -36,11 +36,15 @@ namespace rmw_dds_common
  * \param[out] compatibility: `RMW_QOS_COMPATIBILITY_OK` if the QoS profiles are compatible, or
  *   `RMW_QOS_COMPATIBILITY_WARNING` if the QoS profiles might be compatible, or
  *   `RMW_QOS_COMPATIBILITY_ERROR` if the QoS profiles are not compatible.
- * \param[out] reason: A detailed reason for a QoS incompatibility.
- *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
+ * \param[out] reason: A detailed reason for a QoS incompatibility or potential incompatibility.
+ *   Must be pre-allocated by the caller.
+ *   This parameter is optional and may be set to `nullptr` if the reason information is not
+ *   desired.
  * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
+ *   If `reason` is `nullptr`, then this parameter must be zero.
  * \return `RMW_RET_OK` if the check was successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `reason` is `nullptr` and  `reason_size` is not zero, or
  * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
  * \return `RMW_RET_ERROR` if there is an unexpected error.
  */

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -1,0 +1,56 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_DDS_COMMON__QOS_HPP_
+#define RMW_DDS_COMMON__QOS_HPP_
+
+#include "rmw/qos_profiles.h"
+#include "rmw/types.h"
+
+#include "rmw_dds_common/visibility_control.h"
+
+namespace rmw_dds_common
+{
+
+/// Check if two QoS profiles are compatible
+/**
+ * Two QoS profiles are compatible if a publisher and subcription
+ * using the QoS policies can communicate with each other.
+ *
+ * This implements the rmw API \ref rmw_qos_profile_check_compatible().
+ * See \ref rmw_qos_profile_check_compatible() for more information.
+ *
+ * \param[in] publisher_profile: The QoS profile used for a publisher.
+ * \param[in] subscription_profile: The QoS profile used for a subscription.
+ * \param[out] compatibility: `RMW_QOS_COMPATIBILITY_OK` if the QoS profiles are compatible, or
+ *   `RMW_QOS_COMPATIBILITY_WARNING` if the QoS profiles might be compatible, or
+ *   `RMW_QOS_COMPATIBILITY_ERROR` if the QoS profiles are not compatible.
+ * \param[out] reason: A detailed reason for a QoS incompatibility.
+ *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
+ * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
+ * \return `RMW_RET_OK` if the check was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown"
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_check_compatible(
+  const rmw_qos_profile_t publisher_qos,
+  const rmw_qos_profile_t subscription_qos,
+  rmw_qos_compatibility_type_t * compatibility,
+  char * reason,
+  size_t reason_size);
+
+}  // namespace rmw_dds_common
+
+#endif  // RMW_DDS_COMMON__QOS_HPP_

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -40,7 +40,9 @@ namespace rmw_dds_common
  *   Must be pre-allocated by the caller. This parameter is optional and may be set to `NULL`.
  * \param[in] reason_size: Size of the string buffer `reason`, if one is provided.
  * \return `RMW_RET_OK` if the check was successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown"
+ * \return `RMW_RET_INVALID_ARGUMENT` if `compatiblity` is NULL, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if any of the policies have value "unknown".
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_DDS_COMMON_PUBLIC
 rmw_ret_t

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -17,6 +17,7 @@
 #include <sstream>
 #include <string>
 
+#include "rmw/error_handling.h"
 #include "rmw/qos_profiles.h"
 
 namespace rmw_dds_common
@@ -76,7 +77,7 @@ qos_profile_check_compatible(
   size_t reason_size)
 {
   if (!compatibility) {
-    _write_to_buffer("ERROR: compatibility parameter is null", reason, reason_size);
+    RMW_SET_ERROR_MSG("compatibility parameter is null");
     return RMW_RET_INVALID_ARGUMENT;
   }
 
@@ -88,32 +89,32 @@ qos_profile_check_compatible(
   // If there are any "unknown" values, then there is an error
   if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == publisher_qos.reliability) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Publisher reliability is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Publisher reliability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == subscription_qos.reliability) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Subscription reliability is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Subscription reliability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == publisher_qos.durability) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Publisher durability is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Publisher durability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == subscription_qos.durability) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Subscription durability is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Subscription durability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == publisher_qos.liveliness) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Publisher liveliness is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Publisher liveliness is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == subscription_qos.liveliness) {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
-    _write_to_buffer("ERROR: Subscription liveliness is unknown", reason, reason_size);
+    RMW_SET_ERROR_MSG("Subscription liveliness is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -113,6 +113,11 @@ qos_profile_check_compatible(
   // Presume profiles are compatible until proven otherwise
   *compatibility = RMW_QOS_COMPATIBILITY_OK;
 
+  // Initialize reason buffer
+  if (reason) {
+    reason[0] = '\0';
+  }
+
   // Best effort publisher and reliable subscription
   if (publisher_qos.reliability == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT &&
     subscription_qos.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE)

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -76,7 +76,7 @@ qos_profile_check_compatible(
   size_t reason_size)
 {
   if (!compatibility) {
-    _write_to_buffer("ERROR: compatiblity parameter is null", reason, reason_size);
+    _write_to_buffer("ERROR: compatibility parameter is null", reason, reason_size);
     return RMW_RET_INVALID_ARGUMENT;
   }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -53,18 +53,18 @@ operator<<(std::ostream & out, const rmw_time_t & t)
 }
 
 static void
-_write_to_buffer(const std::string message, char * buffer, size_t buffer_size)
+_write_to_buffer(const char * message, char * buffer, size_t buffer_size)
 {
   // Only write if a buffer is provided
   if (!buffer || buffer_size == 0u) {
     return;
   }
-  size_t write_size = message.size();
+  size_t write_size = sizeof(message);
   // Only write up to the buffers max size
   if (write_size > buffer_size) {
     write_size = buffer_size;
   }
-  strncpy(buffer, message.c_str(), write_size);
+  strncpy(buffer, message, write_size);
 }
 
 rmw_ret_t
@@ -234,7 +234,7 @@ qos_profile_check_compatible(
 
   // Write any issues to the output buffer (if one is provided)
   if (RMW_QOS_COMPATIBILITY_OK != *compatibility) {
-    _write_to_buffer(reason_ss.str(), reason, reason_size);
+    _write_to_buffer(reason_ss.str().c_str(), reason, reason_size);
   }
 
   return RMW_RET_OK;

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -93,7 +93,7 @@ qos_profile_check_compatible(
   *compatibility = RMW_QOS_COMPATIBILITY_OK;
 
   // Initialize reason buffer
-  if (reason) {
+  if (reason && reason_size != 0u) {
     reason[0] = '\0';
   }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -84,40 +84,34 @@ qos_profile_check_compatible(
     return RMW_RET_INVALID_ARGUMENT;
   }
 
-  // Presume profiles are compatible until proven otherwise
-  *compatibility = RMW_QOS_COMPATIBILITY_OK;
-
   // If there are any "unknown" values, then there is an error
   if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == publisher_qos.reliability) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Publisher reliability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == subscription_qos.reliability) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Subscription reliability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == publisher_qos.durability) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Publisher durability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == subscription_qos.durability) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Subscription durability is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == publisher_qos.liveliness) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Publisher liveliness is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
   if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == subscription_qos.liveliness) {
-    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     RMW_SET_ERROR_MSG("Subscription liveliness is unknown");
     return RMW_RET_INVALID_ARGUMENT;
   }
+
+  // Presume profiles are compatible until proven otherwise
+  *compatibility = RMW_QOS_COMPATIBILITY_OK;
 
   // Best effort publisher and reliable subscription
   if (publisher_qos.reliability == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT &&

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
+#include "rmw_dds_common/qos.hpp"
+
 #include <sstream>
+#include <string>
 
 #include "rmw/qos_profiles.h"
-
-#include "rmw_dds_common/qos.hpp"
 
 namespace rmw_dds_common
 {

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -1,0 +1,243 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include <sstream>
+
+#include "rmw/qos_profiles.h"
+
+#include "rmw_dds_common/qos.hpp"
+
+namespace rmw_dds_common
+{
+
+static bool
+operator==(rmw_time_t t1, rmw_time_t t2)
+{
+  return t1.sec == t2.sec && t1.nsec == t2.nsec;
+}
+
+static bool
+operator!=(rmw_time_t t1, rmw_time_t t2)
+{
+  return !(t1 == t2);
+}
+
+static bool
+operator<(rmw_time_t t1, rmw_time_t t2)
+{
+  if (t1.sec < t2.sec) {
+    return true;
+  } else if (t1.sec == t2.sec && t1.nsec < t2.nsec) {
+    return true;
+  }
+  return false;
+}
+
+static std::ostream &
+operator<<(std::ostream & out, const rmw_time_t & t)
+{
+  out << "{" << t.sec << "s " << t.nsec << "ns}";
+  return out;
+}
+
+static void
+_write_to_buffer(const std::string message, char * buffer, size_t buffer_size)
+{
+  // Only write if a buffer is provided
+  if (!buffer || buffer_size == 0u) {
+    return;
+  }
+  size_t write_size = message.size();
+  // Only write up to the buffers max size
+  if (write_size > buffer_size) {
+    write_size = buffer_size;
+  }
+  strncpy(buffer, message.c_str(), write_size);
+}
+
+rmw_ret_t
+qos_profile_check_compatible(
+  const rmw_qos_profile_t publisher_qos,
+  const rmw_qos_profile_t subscription_qos,
+  rmw_qos_compatibility_type_t * compatibility,
+  char * reason,
+  size_t reason_size)
+{
+  if (!compatibility) {
+    _write_to_buffer("ERROR: compatiblity parameter is null", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  std::ostringstream reason_ss;
+
+  // Presume profiles are compatible until proven otherwise
+  *compatibility = RMW_QOS_COMPATIBILITY_OK;
+
+  // If there are any "unknown" values, then there is an error
+  if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == publisher_qos.reliability) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Publisher reliability is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (RMW_QOS_POLICY_RELIABILITY_UNKNOWN == subscription_qos.reliability) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Subscription reliability is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == publisher_qos.durability) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Publisher durability is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (RMW_QOS_POLICY_DURABILITY_UNKNOWN == subscription_qos.durability) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Subscription durability is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == publisher_qos.liveliness) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Publisher liveliness is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (RMW_QOS_POLICY_LIVELINESS_UNKNOWN == subscription_qos.liveliness) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    _write_to_buffer("ERROR: Subscription liveliness is unknown", reason, reason_size);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  // Best effort publisher and reliable subscription
+  if (publisher_qos.reliability == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT &&
+    subscription_qos.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE)
+  {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    reason_ss << "ERROR: Best effort publisher and reliable subscription;";
+  }
+
+  // Volatile publisher and transient local subscription
+  if (publisher_qos.durability == RMW_QOS_POLICY_DURABILITY_VOLATILE &&
+    subscription_qos.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+  {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    reason_ss << "ERROR: Volatile publisher and transient local subscription;";
+  }
+
+  const rmw_time_t & pub_deadline = publisher_qos.deadline;
+  const rmw_time_t & sub_deadline = subscription_qos.deadline;
+  const rmw_time_t deadline_default = RMW_QOS_DEADLINE_DEFAULT;
+
+  // No deadline for publisher and deadline for subscription
+  if (pub_deadline == deadline_default && sub_deadline != deadline_default) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    reason_ss << "ERROR: Subscription has a deadline, but publisher does not;";
+  }
+
+  // Subscription deadline is less than publisher deadline
+  if (pub_deadline != deadline_default && sub_deadline != deadline_default) {
+    if (sub_deadline < pub_deadline) {
+      *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+      reason_ss << "ERROR: Subscription deadline is less than publisher deadline " <<
+        "(" << sub_deadline << " < " << pub_deadline << ");";
+    }
+  }
+
+  // Automatic liveliness for publisher and manual by topic for subscription
+  if (publisher_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_AUTOMATIC &&
+    subscription_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC)
+  {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    reason_ss << "ERROR: Publisher's liveliness is automatic and subscription's liveliness is " <<
+      "manual by topic;";
+  }
+
+  const rmw_time_t & pub_lease = publisher_qos.liveliness_lease_duration;
+  const rmw_time_t & sub_lease = subscription_qos.liveliness_lease_duration;
+  const rmw_time_t lease_default = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+
+  // No lease duration for publisher and lease duration for subscription
+  if (pub_lease == lease_default && sub_lease != lease_default) {
+    *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+    reason_ss << "ERROR: Subscription has a liveliness lease duration, but publisher does not;";
+  }
+
+  // Subscription lease duration is less than publisher lease duration
+  if (pub_lease != lease_default && sub_lease != lease_default) {
+    if (sub_lease < pub_lease) {
+      *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
+      reason_ss << "ERROR: Subscription liveliness lease duration is less than publisher " <<
+        "liveliness lease duration (" << sub_lease << " < " << pub_lease << ");";
+    }
+  }
+
+  // Only check for warnings if there are no errors
+  if (RMW_QOS_COMPATIBILITY_OK == *compatibility) {
+    // Reliability for publisher is "system default" and subscription is reliable
+    if (publisher_qos.reliability == RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT &&
+      subscription_qos.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE)
+    {
+      *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+      reason_ss << "WARNING: Reliable subscription, but publisher is system default;";
+    } else {
+      // Reliability for publisher is best effort and subscription is "system default"
+      if (publisher_qos.reliability == RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT &&
+        subscription_qos.reliability == RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT)
+      {
+        *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+        reason_ss << "WARNING: Best effort publisher, but subscription is system default;";
+      }
+    }
+
+    // Durability for publisher is "system default" and subscription is transient local
+    if (publisher_qos.durability == RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT &&
+      subscription_qos.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+    {
+      *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+      reason_ss << "WARNING: Transient local subscription, but publisher is system default;";
+    } else {
+      // Durability for publisher is volatile and subscription is "system default"
+      if (publisher_qos.durability == RMW_QOS_POLICY_DURABILITY_VOLATILE &&
+        subscription_qos.durability == RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT)
+      {
+        *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+        reason_ss << "WARNING: Volatile publisher, but subscription is system default;";
+      }
+    }
+
+    // Automatic liveliness for publisher and "system default" for subscription
+    if (publisher_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_AUTOMATIC &&
+      subscription_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT)
+    {
+      *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+      reason_ss << "WARNING: Publisher's liveliness is automatic, but subscription's is " <<
+        "system default;";
+    } else {
+      if (publisher_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT &&
+        subscription_qos.liveliness == RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC)
+      {
+        *compatibility = RMW_QOS_COMPATIBILITY_WARNING;
+        reason_ss << "WARNING: Subscription's liveliness is manual by topic, but publisher's " <<
+          "is system default;";
+      }
+    }
+  }
+
+  // Write any issues to the output buffer (if one is provided)
+  if (RMW_QOS_COMPATIBILITY_OK != *compatibility) {
+    _write_to_buffer(reason_ss.str(), reason, reason_size);
+  }
+
+  return RMW_RET_OK;
+}
+
+}  // namespace rmw_dds_common

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -81,6 +81,11 @@ qos_profile_check_compatible(
     return RMW_RET_INVALID_ARGUMENT;
   }
 
+  if (!reason && reason_size != 0u) {
+    RMW_SET_ERROR_MSG("reason parameter is null, but reason_size parameter is not zero");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
   std::ostringstream reason_ss;
 
   // Presume profiles are compatible until proven otherwise

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -1,0 +1,616 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "rmw/types.h"
+
+#include "rmw_dds_common/qos.hpp"
+
+static rmw_qos_profile_t
+get_qos_profile_fixture()
+{
+  return {
+    RMW_QOS_POLICY_HISTORY_KEEP_LAST,
+    5,
+    RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+    RMW_QOS_POLICY_DURABILITY_VOLATILE,
+    RMW_QOS_DEADLINE_DEFAULT,
+    RMW_QOS_LIFESPAN_DEFAULT,
+    RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
+    RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+    false
+  };
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_reliability)
+{
+  // Reliable pub, reliable sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+
+  // Reliable pub, best effort sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+
+  // Best effort pub, best effort sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+
+  // Best effort pub, reliable sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_durability)
+{
+  // Volatile pub, volatile sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Volatile pub, transient local sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Transient local pub, transient local sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Transient local pub, volatile sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_deadline)
+{
+  // No deadline pub, no deadline sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.deadline = RMW_QOS_DEADLINE_DEFAULT;
+    sub_qos.deadline = RMW_QOS_DEADLINE_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+
+  // No deadline pub, deadline sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.deadline = RMW_QOS_DEADLINE_DEFAULT;
+    sub_qos.deadline = {1, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+
+  // Deadline pub > deadline sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.deadline = {1, 1};
+    sub_qos.deadline = {1, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Deadline pub == deadline sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.deadline = {1, 1};
+    sub_qos.deadline = {1, 1};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Deadline pub < deadline sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.deadline = {1, 1};
+    sub_qos.deadline = {2, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_liveliness)
+{
+  // Automatic pub, automatic sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Automatic pub, manual sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Manual pub, manual sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Manual pub, automatic sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
+{
+  // No duration pub, no duration sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+    sub_qos.liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // No duration pub, some duration sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+    sub_qos.liveliness_lease_duration = {1, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Lease duration pub == lease duration sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness_lease_duration = {1, 0};
+    sub_qos.liveliness_lease_duration = {1, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+  // Lease duration pub > lease duration sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness_lease_duration = {1, 1};
+    sub_qos.liveliness_lease_duration = {1, 0};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Lease duration pub < lease duration sub
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness_lease_duration = {1, 1};
+    sub_qos.liveliness_lease_duration = {2, 1};
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+    EXPECT_EQ(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_system_default)
+{
+  // Some policies set to "system default" should cause a warning
+
+  // Pub best effort, sub system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub system default, sub reliable
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub volatile, sub system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub system default, sub transient local
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub automatic, sub system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub system default, sub manual by topic
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_unknown)
+{
+  // Policies set to "unknown" should cause an return error
+
+  // Pub reliable unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Sub reliable unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub durability unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Sub durability unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub liveliness unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Sub liveliness unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_no_reason)
+{
+  // Compatible
+  {
+    rmw_qos_compatibility_type_t compatible;
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, nullptr, 0u);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_OK);
+  }
+  // Incompatible
+  {
+    rmw_qos_compatibility_type_t compatible;
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, nullptr, 0u);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+  }
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_invalid)
+{
+  // Null compatible parameter
+  const size_t reason_size = 2048;
+  char reason[2048] = "";
+  rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+  rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+  rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+    pub_qos, sub_qos, nullptr, reason, reason_size);
+  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+}

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -489,9 +489,24 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
 
 TEST(test_qos, test_qos_profile_check_compatible_unknown)
 {
-  // Policies set to "unknown" should cause an return error
+  // Some policies set to "unknown" should cause a warning
 
-  // Pub reliable unknown
+  // Pub best effort, sub unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Pub unknown, sub reliable
   {
     rmw_qos_compatibility_type_t compatible;
     const size_t reason_size = 2048u;
@@ -499,23 +514,29 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
   }
-  // Sub reliable unknown
+  // Pub volatile, sub unknown
   {
     rmw_qos_compatibility_type_t compatible;
     const size_t reason_size = 2048u;
     char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
-    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
   }
-  // Pub durability unknown
+  // Pub unknown, sub transient local
   {
     rmw_qos_compatibility_type_t compatible;
     const size_t reason_size = 2048u;
@@ -523,23 +544,29 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
   }
-  // Sub durability unknown
+  // Pub automatic, sub unknown
   {
     rmw_qos_compatibility_type_t compatible;
     const size_t reason_size = 2048u;
     char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
-    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
   }
-  // Pub liveliness unknown
+  // Pub unknown, sub manual by topic
   {
     rmw_qos_compatibility_type_t compatible;
     const size_t reason_size = 2048u;
@@ -547,21 +574,12 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-  }
-  // Sub liveliness unknown
-  {
-    rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048u;
-    char reason[2048];
-    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
-    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
-    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
-    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
-      pub_qos, sub_qos, &compatible, reason, reason_size);
-    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
   }
 }
 

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -41,8 +41,8 @@ TEST(test_qos, test_qos_profile_check_compatible_reliability)
   // Reliable pub, reliable sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
@@ -57,8 +57,8 @@ TEST(test_qos, test_qos_profile_check_compatible_reliability)
   // Reliable pub, best effort sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
@@ -73,8 +73,8 @@ TEST(test_qos, test_qos_profile_check_compatible_reliability)
   // Best effort pub, best effort sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -89,8 +89,8 @@ TEST(test_qos, test_qos_profile_check_compatible_reliability)
   // Best effort pub, reliable sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -108,8 +108,8 @@ TEST(test_qos, test_qos_profile_check_compatible_durability)
   // Volatile pub, volatile sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
@@ -123,8 +123,8 @@ TEST(test_qos, test_qos_profile_check_compatible_durability)
   // Volatile pub, transient local sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
@@ -138,8 +138,8 @@ TEST(test_qos, test_qos_profile_check_compatible_durability)
   // Transient local pub, transient local sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
@@ -153,8 +153,8 @@ TEST(test_qos, test_qos_profile_check_compatible_durability)
   // Transient local pub, volatile sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
@@ -172,8 +172,8 @@ TEST(test_qos, test_qos_profile_check_compatible_deadline)
   // No deadline pub, no deadline sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.deadline = RMW_QOS_DEADLINE_DEFAULT;
@@ -188,8 +188,8 @@ TEST(test_qos, test_qos_profile_check_compatible_deadline)
   // No deadline pub, deadline sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.deadline = RMW_QOS_DEADLINE_DEFAULT;
@@ -204,8 +204,8 @@ TEST(test_qos, test_qos_profile_check_compatible_deadline)
   // Deadline pub > deadline sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.deadline = {1, 1};
@@ -219,8 +219,8 @@ TEST(test_qos, test_qos_profile_check_compatible_deadline)
   // Deadline pub == deadline sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.deadline = {1, 1};
@@ -234,8 +234,8 @@ TEST(test_qos, test_qos_profile_check_compatible_deadline)
   // Deadline pub < deadline sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.deadline = {1, 1};
@@ -253,8 +253,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness)
   // Automatic pub, automatic sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
@@ -268,8 +268,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness)
   // Automatic pub, manual sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
@@ -283,8 +283,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness)
   // Manual pub, manual sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
@@ -298,8 +298,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness)
   // Manual pub, automatic sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
@@ -317,8 +317,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
   // No duration pub, no duration sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
@@ -332,8 +332,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
   // No duration pub, some duration sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
@@ -347,8 +347,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
   // Lease duration pub == lease duration sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness_lease_duration = {1, 0};
@@ -362,8 +362,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
   // Lease duration pub > lease duration sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness_lease_duration = {1, 1};
@@ -377,8 +377,8 @@ TEST(test_qos, test_qos_profile_check_compatible_liveliness_lease_duration)
   // Lease duration pub < lease duration sub
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness_lease_duration = {1, 1};
@@ -398,8 +398,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub best effort, sub system default
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -413,8 +413,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub system default, sub reliable
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
@@ -428,8 +428,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub volatile, sub system default
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
@@ -443,8 +443,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub system default, sub transient local
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
@@ -458,8 +458,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub automatic, sub system default
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
@@ -473,8 +473,8 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
   // Pub system default, sub manual by topic
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
@@ -494,80 +494,74 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
   // Pub reliable unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub reliable unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Pub durability unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub durability unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     sub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Pub liveliness unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub liveliness unknown
   {
     rmw_qos_compatibility_type_t compatible;
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(0u, strnlen(reason, 1));
   }
 }
 
@@ -619,8 +613,8 @@ TEST(test_qos, test_qos_profile_check_compatible_invalid)
 {
   // Null compatible parameter
   {
-    const size_t reason_size = 2048;
-    char reason[2048] = "";
+    const size_t reason_size = 2048u;
+    char reason[2048];
     rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -425,6 +425,21 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
     EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
     EXPECT_LT(0u, strnlen(reason, 1));
   }
+  // Both reliability system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
   // Pub volatile, sub system default
   {
     rmw_qos_compatibility_type_t compatible;
@@ -455,6 +470,21 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
     EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
     EXPECT_LT(0u, strnlen(reason, 1));
   }
+  // Both durability system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
   // Pub automatic, sub system default
   {
     rmw_qos_compatibility_type_t compatible;
@@ -479,6 +509,21 @@ TEST(test_qos, test_qos_profile_check_compatible_system_default)
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
     sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Both liveliness system default
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_OK);
@@ -521,6 +566,21 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
     EXPECT_LT(0u, strnlen(reason, 1));
   }
+  // Both reliability unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
   // Pub volatile, sub unknown
   {
     rmw_qos_compatibility_type_t compatible;
@@ -551,6 +611,21 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
     EXPECT_LT(0u, strnlen(reason, 1));
   }
+  // Both durability unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    sub_qos.durability = RMW_QOS_POLICY_DURABILITY_UNKNOWN;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
   // Pub automatic, sub unknown
   {
     rmw_qos_compatibility_type_t compatible;
@@ -575,6 +650,21 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
     sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_WARNING);
+    EXPECT_LT(0u, strnlen(reason, 1));
+  }
+  // Both liveliness unknown
+  {
+    rmw_qos_compatibility_type_t compatible;
+    const size_t reason_size = 2048u;
+    char reason[2048];
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    pub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
+    sub_qos.liveliness = RMW_QOS_POLICY_LIVELINESS_UNKNOWN;
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_OK);

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -502,8 +502,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub reliable unknown
   {
@@ -516,8 +515,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Pub durability unknown
   {
@@ -530,8 +528,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub durability unknown
   {
@@ -544,8 +541,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Pub liveliness unknown
   {
@@ -558,8 +554,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
   // Sub liveliness unknown
   {
@@ -572,8 +567,7 @@ TEST(test_qos, test_qos_profile_check_compatible_unknown)
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, reason, reason_size);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
-    EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
-    EXPECT_LT(0u, strnlen(reason, 1));
+    EXPECT_EQ(0u, strnlen(reason, 1));
   }
 }
 

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -600,11 +600,22 @@ TEST(test_qos, test_qos_profile_check_compatible_no_reason)
 TEST(test_qos, test_qos_profile_check_compatible_invalid)
 {
   // Null compatible parameter
-  const size_t reason_size = 2048;
-  char reason[2048] = "";
-  rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
-  rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
-  rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
-    pub_qos, sub_qos, nullptr, reason, reason_size);
-  EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  {
+    const size_t reason_size = 2048;
+    char reason[2048] = "";
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, nullptr, reason, reason_size);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
+  // Null reason, but non-zero reason_size
+  {
+    rmw_qos_compatibility_type_t compatible;
+    rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+    rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+    rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+      pub_qos, sub_qos, &compatible, nullptr, 3u);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
 }

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -702,7 +702,7 @@ TEST(test_qos, test_qos_profile_check_compatible_no_reason)
 TEST(test_qos, test_qos_profile_check_compatible_reason_buffer_too_small)
 {
   // We expect a message larger than 10 characters
-  char reason[10] = "";
+  char reason[10];
   size_t reason_size = 10u;
   rmw_qos_compatibility_type_t compatible;
   rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
@@ -715,6 +715,23 @@ TEST(test_qos, test_qos_profile_check_compatible_reason_buffer_too_small)
   EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
   // Expect the first 10 characters including the terminating null character
   EXPECT_STREQ(reason, "ERROR: Be");
+}
+
+TEST(test_qos, test_qos_profile_check_compatible_reason_buffer_size_zero)
+{
+  char reason[10] = "untouched";
+  // With reason size zero, we don't expect any message to be written
+  size_t reason_size = 0u;
+  rmw_qos_compatibility_type_t compatible;
+  rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+  rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+  pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+    pub_qos, sub_qos, &compatible, reason, reason_size);
+  EXPECT_EQ(ret, RMW_RET_OK);
+  EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+  EXPECT_STREQ(reason, "untouched");
 }
 
 TEST(test_qos, test_qos_profile_check_compatible_invalid)

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -597,6 +597,24 @@ TEST(test_qos, test_qos_profile_check_compatible_no_reason)
   }
 }
 
+TEST(test_qos, test_qos_profile_check_compatible_reason_buffer_too_small)
+{
+  // We expect a message larger than 10 characters
+  char reason[10] = "";
+  size_t reason_size = 10u;
+  rmw_qos_compatibility_type_t compatible;
+  rmw_qos_profile_t pub_qos = get_qos_profile_fixture();
+  rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
+  pub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+  sub_qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
+    pub_qos, sub_qos, &compatible, reason, reason_size);
+  EXPECT_EQ(ret, RMW_RET_OK);
+  EXPECT_EQ(compatible, RMW_QOS_COMPATIBILITY_ERROR);
+  // Expect the first 10 characters including the terminating null character
+  EXPECT_STREQ(reason, "ERROR: Be");
+}
+
 TEST(test_qos, test_qos_profile_check_compatible_invalid)
 {
   // Null compatible parameter


### PR DESCRIPTION
Given QoS profiles for a publisher and a subscription, this function
will return `true` if the profiles are compatible.
Compatible profiles implies that the subscription and publisher will
be able to communicate.

Connected to https://github.com/ros2/rmw/pull/299