### PR TITLE
Add support for Certificate Revocation List files.

### DIFF
--- a/rmw_dds_common/src/security.cpp
+++ b/rmw_dds_common/src/security.cpp
@@ -35,6 +35,10 @@ bool get_security_files(
     {"PERMISSIONS", "permissions.p7s"},
   };
 
+  const std::unordered_map<std::string, std::string> optional_files{
+    {"CRL", "crl.pem"},
+  };
+
   for (const std::pair<const std::string, std::string> & el : required_files) {
     rcpputils::fs::path full_path(secure_root);
     full_path /= el.second;
@@ -44,6 +48,14 @@ bool get_security_files(
     }
 
     result[el.first] = prefix + full_path.string();
+  }
+
+  for (const std::pair<const std::string, std::string> & el : optional_files) {
+    rcpputils::fs::path full_path(secure_root);
+    full_path /= el.second;
+    if (full_path.is_regular_file()) {
+      result[el.first] = prefix + full_path.string();
+    }
   }
 
   return true;

--- a/rmw_dds_common/test/test_security.cpp
+++ b/rmw_dds_common/test/test_security.cpp
@@ -129,3 +129,49 @@ TEST(test_security, file_missing)
   ASSERT_FALSE(rmw_dds_common::get_security_files("", dir.string(), security_files));
   ASSERT_EQ(security_files.size(), 0UL);
 }
+
+TEST(test_security, optional_file_exist)
+{
+  rcpputils::fs::path dir = rcpputils::fs::path("./test_folder");
+  rcpputils::fs::remove_all(dir);
+  EXPECT_TRUE(rcpputils::fs::create_directories(dir));
+  EXPECT_TRUE(rcpputils::fs::exists(dir));
+  EXPECT_TRUE(rcpputils::fs::is_directory(dir));
+
+  std::array<std::string, 7> required_files = {
+    "identity_ca.cert.pem", "cert.pem", "key.pem",
+    "permissions_ca.cert.pem", "governance.p7s", "permissions.p7s", "crl.pem",
+  };
+  for (const std::string & filename : required_files) {
+    rcpputils::fs::path full_path = dir / filename;
+    std::ofstream output_buffer{full_path.string()};
+    output_buffer << "test";
+    ASSERT_TRUE(rcpputils::fs::exists(full_path));
+  }
+
+  std::unordered_map<std::string, std::string> security_files;
+  ASSERT_TRUE(rmw_dds_common::get_security_files("", dir.string(), security_files));
+
+  EXPECT_EQ(
+    security_files["IDENTITY_CA"],
+    rcpputils::fs::path("./test_folder/identity_ca.cert.pem").string());
+  EXPECT_EQ(
+    security_files["CERTIFICATE"],
+    rcpputils::fs::path("./test_folder/cert.pem").string());
+  EXPECT_EQ(
+    security_files["PRIVATE_KEY"],
+    rcpputils::fs::path("./test_folder/key.pem").string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS_CA"],
+    rcpputils::fs::path("./test_folder/permissions_ca.cert.pem").string());
+  EXPECT_EQ(
+    security_files["GOVERNANCE"],
+    rcpputils::fs::path("./test_folder/governance.p7s").string());
+  EXPECT_EQ(
+    security_files["PERMISSIONS"],
+    rcpputils::fs::path("./test_folder/permissions.p7s").string());
+
+  EXPECT_EQ(
+    security_files["CRL"],
+    rcpputils::fs::path("./test_folder/crl.pem").string());
+}


### PR DESCRIPTION
At least Fast-RTPS and CycloneDDS support Certificate
Revocation Lists, so add it as one of the possible files
in the enclave.  Note that it is an optional file; if
an enclave doesn't have it, then the key will be missing
from the returned map.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Besides the maintainers of this package, also pinging @ruffsl , @mikaelarguedas , and @SidFaber .  The addition of this file is essentially expanding the on-disk "API" of an SROS2 security enclave to include the `crl.pem` file, so I'd appreciate any feedback that you may have.