### PR TITLE
silence clang warning (`range-loop-construct`)

### DIFF
--- a/rmw_dds_common/src/security.cpp
+++ b/rmw_dds_common/src/security.cpp
@@ -35,7 +35,7 @@ bool get_security_files(
     {"PERMISSIONS", "permissions.p7s"},
   };
 
-  for (const auto & el : required_files) {
+  for (const std::pair<const std::string, std::string> & el : required_files) {
     rcpputils::fs::path full_path(secure_root);
     full_path /= el.second;
     if (!full_path.is_regular_file()) {

--- a/rmw_dds_common/src/security.cpp
+++ b/rmw_dds_common/src/security.cpp
@@ -35,7 +35,7 @@ bool get_security_files(
     {"PERMISSIONS", "permissions.p7s"},
   };
 
-  for (const std::pair<std::string, std::string> & el : required_files) {
+  for (const auto & el : required_files) {
     rcpputils::fs::path full_path(secure_root);
     full_path /= el.second;
     if (!full_path.is_regular_file()) {


### PR DESCRIPTION
I get warnings from clang when compiling the latest master:

```
/Users/karsten/workspace/ros2/ros2_master/src/ros2/rmw_dds_common/rmw_dds_common/src/security.cpp:38:52: error: loop variable 'el' has type 'const std::pair<std::string, std::string> &' (aka 'const pair<basic_string<char, char_traits<char>, allocator<char> >, basic_string<char, char_traits<char>, allocator<char> > > &') but is initialized with type 'const std::__1::__hash_map_const_iterator<std::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char>, std::__1::basic_string<char> >, void *> *> >::value_type' (aka 'const pair<const std::__1::basic_string<char>, std::__1::basic_string<char> >') resulting in a copy [-Werror,-Wrange-loop-construct]
  for (const std::pair<std::string, std::string> & el : required_files) {
                                                   ^
/Users/karsten/workspace/ros2/ros2_master/src/ros2/rmw_dds_common/rmw_dds_common/src/security.cpp:38:8: note: use non-reference type 'std::pair<std::string, std::string>' (aka 'pair<basic_string<char, char_traits<char>, allocator<char> >, basic_string<char, char_traits<char>, allocator<char> > >') to keep the copy or type 'const std::__1::__hash_map_const_iterator<std::__1::__hash_const_iterator<std::__1::__hash_node<std::__1::__hash_value_type<std::__1::basic_string<char>, std::__1::basic_string<char> >, void *> *> >::value_type &' (aka 'const pair<const std::__1::basic_string<char>, std::__1::basic_string<char> > &') to prevent copying
  for (const std::pair<std::string, std::string> & el : required_files) {
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```