### PR TITLE
Add functions to get compatible QoS profiles

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -104,7 +104,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_qos test/test_qos.cpp)
   if(TARGET test_qos)
-    target_link_libraries(test_qos ${PROJECT_NAME}_library)
+    target_link_libraries(test_qos ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools)
   endif()
 
   ament_add_gmock(test_time_utils test/test_time_utils.cpp)

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -94,6 +94,43 @@ qos_profile_get_most_compatible_for_subscription(
   rmw_topic_endpoint_info_array_t * incompatible_publishers,
   rcutils_allocator_t * allocator);
 
+/// Get compatible QoS policies for a publisher.
+/**
+ * Given one or more subscription endpoints, return a QoS profile for a publisher
+ * that is compatible with the majority of the subscriptions while maintaining the highest
+ * level of service possible.
+ *
+ * This implements the rmw API \ref rmw_qos_profile_get_most_compatible_for_subscription().
+ * See \ref rmw_qos_profile_get_most_compatible_for_subscription() for more information.
+ *
+ * \param[in] subscriptions_info: Endpoint information for subscriptions.
+ * \param[out] publisher_profile: QoS profile that is compatible with the majority of
+ *   the input subscriptions.
+ * \param[out] incompatible_subscriptions: Subscription endpoints that are incompatible with the
+ *   output publisher QoS profile.
+ *   This parameter is optional and may be `nullptr`.
+ *   If provided, it must be zero initialized and you must also provide a valid allocator.
+ * \param[in] allocator: Used allocate memory for `incompatible_subscriptions`.
+ *   May be `nullptr` if `incompatible_subscriptions` is also `nullptr`.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscriptions_info` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscriptions_info.size` is 0, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profile` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `incompatible_subscriptions` is not `nullptr` and
+ *   is not zero initialized, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `incompatible_subscriptions` is not `nullptr` and
+ *   `allocator` is invalid, or
+ * \returns `RMW_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_most_compatible_for_publisher(
+  const rmw_topic_endpoint_info_array_t * subscriptions_info,
+  rmw_qos_profile_t * publisher_profile,
+  rmw_topic_endpoint_info_array_t * incompatible_subscriptions,
+  rcutils_allocator_t * allocator);
+
 }  // namespace rmw_dds_common
 
 #endif  // RMW_DDS_COMMON__QOS_HPP_

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -56,6 +56,37 @@ qos_profile_check_compatible(
   char * reason,
   size_t reason_size);
 
+/// Get compatible QoS policies for a subscription.
+/**
+ * Given one or more publisher QoS profiles, return a QoS profile for a subscirption
+ * that is compatible with the majority of the publisher profiles while maintaining the highest
+ * level of service possible.
+ *
+ * This implements the rmw API \ref rmw_qos_profile_get_most_compatible_for_subscription().
+ * See \ref rmw_qos_profile_get_most_compatible_for_subscription() for more information.
+ *
+ * \param[in] publisher_profiles: An array of QoS profiles used for publishers.
+ * \param[out] subscription_profile: QoS policies that are compatible with the majorty of
+ *   the input publisher profiles.
+ * \param[out] compatible_publisher_profiles: An array of boolean values indicating if the
+ *   corresponding Qos profile at the same index in the publisher profiles array is compatible
+ *   with the resultant subscription QoS profile or not.
+ *   This parameter is optional and may be `nullptr`.
+ *   If provided, it must be the same length as the publisher profiles array.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profiles` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profiles_length` is 0, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscription_profile` is `nullptr`, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_most_compatible_for_subscription(
+  const rmw_qos_profile_t * publisher_profiles,
+  size_t publisher_profiles_length,
+  rmw_qos_profile_t * subscription_profile,
+  bool * compatible_publisher_profiles);
+
 }  // namespace rmw_dds_common
 
 #endif  // RMW_DDS_COMMON__QOS_HPP_

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -16,6 +16,7 @@
 #define RMW_DDS_COMMON__QOS_HPP_
 
 #include "rmw/qos_profiles.h"
+#include "rmw/topic_endpoint_info_array.h"
 #include "rmw/types.h"
 
 #include "rmw_dds_common/visibility_control.h"
@@ -58,34 +59,40 @@ qos_profile_check_compatible(
 
 /// Get compatible QoS policies for a subscription.
 /**
- * Given one or more publisher QoS profiles, return a QoS profile for a subscirption
- * that is compatible with the majority of the publisher profiles while maintaining the highest
+ * Given one or more publisher endpoints, return a QoS profile for a subscription
+ * that is compatible with the majority of the publishers while maintaining the highest
  * level of service possible.
  *
  * This implements the rmw API \ref rmw_qos_profile_get_most_compatible_for_subscription().
  * See \ref rmw_qos_profile_get_most_compatible_for_subscription() for more information.
  *
- * \param[in] publisher_profiles: An array of QoS profiles used for publishers.
- * \param[out] subscription_profile: QoS policies that are compatible with the majorty of
- *   the input publisher profiles.
- * \param[out] compatible_publisher_profiles: An array of boolean values indicating if the
- *   corresponding QoS profile at the same index in the publisher profiles array is compatible
- *   with the resultant subscription QoS profile or not.
+ * \param[in] publishers_info: Endpoint information for publishers.
+ * \param[out] subscription_profile: QoS profile that is compatible with the majority of
+ *   the input publishers.
+ * \param[out] incompatible_publishers: Publisher endpoints that are incompatible with the output
+ *   subscription QoS profile.
  *   This parameter is optional and may be `nullptr`.
- *   If provided, it must be the same length as the publisher profiles array.
+ *   If provided, it must be zero initialized and you must also provide a valid allocator.
+ * \param[in] allocator: Used allocate memory for `incompatible_publishers`.
+ *   May be `nullptr` if `incompatible_publishers` is also `nullptr`.
  * \return `RMW_RET_OK` if the operation was successful, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profiles` is `nullptr`, or
- * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profiles_length` is 0, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publishers_info` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publishers_info.size` is 0, or
  * \return `RMW_RET_INVALID_ARGUMENT` if `subscription_profile` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `incompatible_publishers` is not `nullptr` and
+ *   is not zero initialized, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `incompatible_publishers` is not `nullptr` and
+ *   `allocator` is invalid, or
+ * \returns `RMW_RET_BAD_ALLOC` if memory allocation fails, or
  * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_DDS_COMMON_PUBLIC
 rmw_ret_t
 qos_profile_get_most_compatible_for_subscription(
-  const rmw_qos_profile_t * publisher_profiles,
-  size_t publisher_profiles_length,
+  const rmw_topic_endpoint_info_array_t * publishers_info,
   rmw_qos_profile_t * subscription_profile,
-  bool * compatible_publisher_profiles);
+  rmw_topic_endpoint_info_array_t * incompatible_publishers,
+  rcutils_allocator_t * allocator);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -69,7 +69,7 @@ qos_profile_check_compatible(
  * \param[out] subscription_profile: QoS policies that are compatible with the majorty of
  *   the input publisher profiles.
  * \param[out] compatible_publisher_profiles: An array of boolean values indicating if the
- *   corresponding Qos profile at the same index in the publisher profiles array is compatible
+ *   corresponding QoS profile at the same index in the publisher profiles array is compatible
  *   with the resultant subscription QoS profile or not.
  *   This parameter is optional and may be `nullptr`.
  *   If provided, it must be the same length as the publisher profiles array.

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -413,9 +413,9 @@ qos_profile_get_most_compatible_for_subscription(
   size_t number_of_reliable = 0u;
   size_t number_of_transient_local = 0u;
   size_t number_of_manual_by_topic = 0u;
-  bool default_deadline = true;
+  bool use_default_deadline = true;
   rmw_time_t largest_deadline = {0u, 0u};
-  bool default_liveliness_lease_duration = true;
+  bool use_default_liveliness_lease_duration = true;
   rmw_time_t largest_liveliness_lease_duration = {0u, 0u};
   for (size_t i = 0u; i < publishers_info->size; ++i) {
     const rmw_qos_profile_t & profile = publishers_info->info_array[i].qos_profile;
@@ -429,13 +429,13 @@ qos_profile_get_most_compatible_for_subscription(
       number_of_manual_by_topic++;
     }
     if (profile.deadline != deadline_default) {
-      default_deadline = false;
+      use_default_deadline = false;
       if (largest_deadline < profile.deadline) {
         largest_deadline = profile.deadline;
       }
     }
     if (profile.liveliness_lease_duration != liveliness_lease_duration_default) {
-      default_liveliness_lease_duration = false;
+      use_default_liveliness_lease_duration = false;
       if (largest_liveliness_lease_duration < profile.liveliness_lease_duration) {
         largest_liveliness_lease_duration = profile.liveliness_lease_duration;
       }
@@ -460,13 +460,13 @@ qos_profile_get_most_compatible_for_subscription(
     subscription_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
   }
 
-  if (default_deadline) {
+  if (use_default_deadline) {
     subscription_profile->deadline = RMW_QOS_DEADLINE_DEFAULT;
   } else {
     subscription_profile->deadline = largest_deadline;
   }
 
-  if (default_liveliness_lease_duration) {
+  if (use_default_liveliness_lease_duration) {
     subscription_profile->liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
   } else {
     subscription_profile->liveliness_lease_duration = largest_liveliness_lease_duration;

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -793,10 +793,10 @@ TEST(test_qos, test_qos_profile_get_most_compatible_for_subscription)
 
     EXPECT_EQ(ret, RMW_RET_OK);
     // Expect the reliability and durability to change, matching publisher QoS
-    EXPECT_EQ(
-      subscription_profile.reliability, publishers_info.info_array[0].qos_profile.reliability);
-    EXPECT_EQ(
-      subscription_profile.durability, publishers_info.info_array[0].qos_profile.durability);
+    const rmw_qos_profile_t & publisher_profile = publishers_info.info_array[0].qos_profile;
+    EXPECT_EQ(subscription_profile.reliability, publisher_profile.reliability);
+    EXPECT_EQ(subscription_profile.durability, publisher_profile.durability);
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.deadline, publisher_profile.deadline));
   }
   // More than one publisher profile
   {
@@ -826,7 +826,7 @@ TEST(test_qos, test_qos_profile_get_most_compatible_for_subscription)
       1,
       RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,  // should result in "best effort" for subscription
       RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
-      RMW_QOS_DEADLINE_DEFAULT,
+      {3u, 0u},  // this deadline should appear in subscription QoS because it is largest
       RMW_QOS_LIFESPAN_DEFAULT,
       RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
       RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
@@ -837,7 +837,7 @@ TEST(test_qos, test_qos_profile_get_most_compatible_for_subscription)
       1,
       RMW_QOS_POLICY_RELIABILITY_RELIABLE,
       RMW_QOS_POLICY_DURABILITY_VOLATILE,  // should result in "volatile" for subscription
-      RMW_QOS_DEADLINE_DEFAULT,
+      {2u, 0u},
       RMW_QOS_LIFESPAN_DEFAULT,
       RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
       RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
@@ -852,6 +852,7 @@ TEST(test_qos, test_qos_profile_get_most_compatible_for_subscription)
     EXPECT_EQ(ret, RMW_RET_OK);
     EXPECT_EQ(subscription_profile.reliability, RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
     EXPECT_EQ(subscription_profile.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.deadline, {3u, 0u}));
     EXPECT_EQ(incompatible_info.size, 0u);
   }
 }


### PR DESCRIPTION
Connects to https://github.com/ros2/rmw/issues/304

Currently, just contains an implementation for the subscription. I'll wait for feedback before adding the equivalent function for publishers.
