### PR TITLE
Add functions for resolving 'best available' QoS policies

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -104,7 +104,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_qos test/test_qos.cpp)
   if(TARGET test_qos)
-    target_link_libraries(test_qos ${PROJECT_NAME}_library)
+    target_link_libraries(test_qos ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools)
   endif()
 
   ament_add_gmock(test_time_utils test/test_time_utils.cpp)

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -151,12 +151,22 @@ using GetEndpointInfoByTopicFunction = std::function<rmw_ret_t(
  * For rules related to adapting 'best available' policies, see
  * \ref `qos_profile_get_best_available_for_subscription`.
  *
+ * This function allocates memory with the node's context allocator.
+ *
  * \param[in] node: Node used to query the graph.
  * \param[in] topic_name: Query info for publishers on this topic name.
  * \param[inout] qos_profile: Any policies that are set to 'best available' will by updated based
  *   on publisher endpoint QoS policies.
  * \param[in] get_endpoint_info: The function used to query for publisher endpoint information.
  *   I.e. an implementation of `rmw_get_publishers_info_by_topic`.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `node` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `topic_name` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `qos_profile` is `nullptr`, or
+ * \return `RMW_RET_INCORRECT_RMW_IMPLEMENTATION` if the `node` implementation
+ *   identifier does not match this implementation, or
+ * \return `RMW_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_DDS_COMMON_PUBLIC
 rmw_ret_t
@@ -174,12 +184,22 @@ qos_profile_get_best_available_for_topic_subscription(
  * For rules related to adapting 'best available' policies, see
  * \ref `qos_profile_get_best_available_for_publisher`.
  *
+ * This function allocates memory with the node's context allocator.
+ *
  * \param[in] node: Node used to query the graph.
  * \param[in] topic_name: Query info for subscriptions on this topic name.
  * \param[inout] qos_profile: Any policies that are set to 'best available' will by updated based
  *   on subscription endpoint QoS policies.
  * \param[in] get_endpoint_info: The function used to query for subscription endpoint information.
  *   I.e. an implementation of `rmw_get_subscriptions_info_by_topic`.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `node` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `topic_name` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `qos_profile` is `nullptr`, or
+ * \return `RMW_RET_INCORRECT_RMW_IMPLEMENTATION` if the `node` implementation
+ *   identifier does not match this implementation, or
+ * \return `RMW_RET_BAD_ALLOC` if memory allocation fails, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
  */
 RMW_DDS_COMMON_PUBLIC
 rmw_ret_t

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -15,7 +15,10 @@
 #ifndef RMW_DDS_COMMON__QOS_HPP_
 #define RMW_DDS_COMMON__QOS_HPP_
 
+#include <functional>
+
 #include "rmw/qos_profiles.h"
+#include "rmw/topic_endpoint_info_array.h"
 #include "rmw/types.h"
 
 #include "rmw_dds_common/visibility_control.h"
@@ -55,6 +58,136 @@ qos_profile_check_compatible(
   rmw_qos_compatibility_type_t * compatibility,
   char * reason,
   size_t reason_size);
+
+/// Get the best available QoS policies for a subscription.
+/**
+ * Given zero or more publisher endpoints, update any BEST_AVAILABLE policies in a subscription QoS
+ * profile such that is matches all publishers while maintaining the highest level of service.
+ *
+ * If reliability is BEST_AVAILABLE, then it will be set to RELIABLE if all publishers are
+ * RELIABLE.
+ * Otherwise, reliability will be set to BEST_EFFORT.
+ *
+ * If durability is BEST_AVAILABLE, then it will be set to TRANSIENT_LOCAL if all publishers are
+ * TRANSIENT_LOCAL.
+ * Otherwise, durability will be set to VOLATILE.
+ *
+ * If liveliness is BEST_AVAILABLE, then it will be set to MANUAL_BY_TOPIC if all publishers are
+ * MANUAL_BY_TOPIC.
+ * Otherwise, liveliness will be set to AUTOMATIC.
+ *
+ * If deadline is BEST_AVAILABLE, then it will be set to DEFAULT if all publishers are DEFAULT.
+ * Otherwise, deadline will be set to the maximum deadline of all publishers.
+ *
+ * If liveliness lease duration is BEST_AVAILABLE, then it will be set to DEFAULT if all
+ * publishers are DEFAULT.
+ * Otherwise, liveliness lease duration will be set to the maximum deadline of all publishers.
+ *
+ * History, history depth, and lifespan policies are not changed by this function.
+ *
+ * \param[in] publishers_info: Endpoint information for publishers.
+ * \param[out] subscription_profile: QoS profile that is compatible with the majority of
+ *   the input publishers.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publishers_info` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscription_profile` is `nullptr`, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_best_available_for_subscription(
+  const rmw_topic_endpoint_info_array_t * publishers_info,
+  rmw_qos_profile_t * subscription_profile);
+
+/// Get the best available QoS policies for a publisher.
+/**
+ * Given zero or more subscription endpoints, update any BEST_AVAILABLE policies in a publisher QoS
+ * profile such that is matches all subscriptions while maintaining the highest level of service.
+ *
+ * If reliability is BEST_AVAILABLE, then it will be set to RELIABLE.
+ *
+ * If durability is BEST_AVAILABLE, then it will be set to TRANSIENT_LOCAL.
+ *
+ * If liveliness is BEST_AVAILABLE, then it will be set to MANUAL_BY_TOPIC if at least one
+ * subscription is MANUAL_BY_TOPIC.
+ * Otherwise, liveliness will be set to AUTOMATIC.
+ *
+ * If deadline is BEST_AVAILABLE, then it will be set to DEFAULT if all subscriptions are DEFAULT.
+ * Otherwise, deadline will be set to the minimum deadline of all subscriptions.
+ *
+ * If liveliness lease duration is BEST_AVAILABLE, then it will be set to DEFAULT if all
+ * subscriptions are DEFAULT.
+ * Otherwise, liveliness lease duration will be set to the mininum deadline of all subscriptions.
+ *
+ * History, history depth, and lifespan policies are not changed by this function.
+ *
+ * \param[in] subscriptions_info: Endpoint information for subscriptions.
+ * \param[out] publisher_profile: QoS profile that is compatible with the majority of
+ *   the input subscriptions.
+ * \return `RMW_RET_OK` if the operation was successful, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `subscriptions_info` is `nullptr`, or
+ * \return `RMW_RET_INVALID_ARGUMENT` if `publisher_profile` is `nullptr`, or
+ * \return `RMW_RET_ERROR` if there is an unexpected error.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_best_available_for_publisher(
+  const rmw_topic_endpoint_info_array_t * subscriptions_info,
+  rmw_qos_profile_t * publisher_profile);
+
+/// Signature matching rmw_get_publishers_info_by_topic and rmw_get_subscriptions_info_by_topic
+using GetEndpointInfoByTopicFunction = std::function<rmw_ret_t(
+      const rmw_node_t *,
+      rcutils_allocator_t *,
+      const char *,
+      bool,
+      rmw_topic_endpoint_info_array_t *)>;
+
+/// Update a subscription QoS profile so that it is compatible with discovered publishers.
+/**
+ * If any policies in `qos_profile` are set to BEST_AVAILABLE, then `get_endpoint_info` will
+ * be called to query endpoint information for adapting the QoS policies.
+ *
+ * For rules related to adapting 'best available' policies, see
+ * \ref `qos_profile_get_best_available_for_subscription`.
+ *
+ * \param[in] node: Node used to query the graph.
+ * \param[in] topic_name: Query info for publishers on this topic name.
+ * \param[inout] qos_profile: Any policies that are set to 'best available' will by updated based
+ *   on publisher endpoint QoS policies.
+ * \param[in] get_endpoint_info: The function used to query for publisher endpoint information.
+ *   I.e. an implementation of `rmw_get_publishers_info_by_topic`.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_best_available_for_topic_subscription(
+  const rmw_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * qos_profile,
+  GetEndpointInfoByTopicFunction get_endpoint_info);
+
+/// Update a publisher QoS profile so that it is compatible with discovered subscriptions.
+/**
+ * If any policies in `qos_profile` are set to 'best available', then `get_endpoint_info` will
+ * be called to query endpoint information for adapting the QoS policies.
+ *
+ * For rules related to adapting 'best available' policies, see
+ * \ref `qos_profile_get_best_available_for_publisher`.
+ *
+ * \param[in] node: Node used to query the graph.
+ * \param[in] topic_name: Query info for subscriptions on this topic name.
+ * \param[inout] qos_profile: Any policies that are set to 'best available' will by updated based
+ *   on subscription endpoint QoS policies.
+ * \param[in] get_endpoint_info: The function used to query for subscription endpoint information.
+ *   I.e. an implementation of `rmw_get_subscriptions_info_by_topic`.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+qos_profile_get_best_available_for_topic_publisher(
+  const rmw_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * qos_profile,
+  GetEndpointInfoByTopicFunction get_endpoint_info);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -209,6 +209,21 @@ qos_profile_get_best_available_for_topic_publisher(
   rmw_qos_profile_t * qos_profile,
   const GetEndpointInfoByTopicFunction & get_endpoint_info);
 
+/// Update best available QoS policies for services and clients.
+/**
+ * Give QoS policies, return a new set of policies that have any BEST_AVAILABLE policies replaced
+ * with default policies for services.
+ *
+ * See `rmw_qos_profile_services_default` for default policy values.
+ *
+ * \param[in] qos_profile: QoS profile to copy and update.
+ * \return A copy of the input QoS profile with any BEST_AVAILABLE policies overwritten with
+ *   default service policies.
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_qos_profile_t
+qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile);
+
 }  // namespace rmw_dds_common
 
 #endif  // RMW_DDS_COMMON__QOS_HPP_

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -174,7 +174,7 @@ qos_profile_get_best_available_for_topic_subscription(
   const rmw_node_t * node,
   const char * topic_name,
   rmw_qos_profile_t * qos_profile,
-  GetEndpointInfoByTopicFunction get_endpoint_info);
+  const GetEndpointInfoByTopicFunction & get_endpoint_info);
 
 /// Update a publisher QoS profile so that it is compatible with discovered subscriptions.
 /**
@@ -207,7 +207,7 @@ qos_profile_get_best_available_for_topic_publisher(
   const rmw_node_t * node,
   const char * topic_name,
   rmw_qos_profile_t * qos_profile,
-  GetEndpointInfoByTopicFunction get_endpoint_info);
+  const GetEndpointInfoByTopicFunction & get_endpoint_info);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -581,7 +581,7 @@ qos_profile_get_best_available_for_topic_subscription(
   const rmw_node_t * node,
   const char * topic_name,
   rmw_qos_profile_t * qos_profile,
-  GetEndpointInfoByTopicFunction get_endpoint_info)
+  const GetEndpointInfoByTopicFunction & get_endpoint_info)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
@@ -614,7 +614,7 @@ qos_profile_get_best_available_for_topic_publisher(
   const rmw_node_t * node,
   const char * topic_name,
   rmw_qos_profile_t * qos_profile,
-  GetEndpointInfoByTopicFunction get_endpoint_info)
+  const GetEndpointInfoByTopicFunction & get_endpoint_info)
 {
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -19,6 +19,7 @@
 
 #include "rcutils/snprintf.h"
 #include "rmw/error_handling.h"
+#include "rmw/get_topic_endpoint_info.h"
 #include "rmw/qos_profiles.h"
 #include "rmw/qos_string_conversions.h"
 
@@ -47,6 +48,13 @@ operator<(rmw_time_t t1, rmw_time_t t2)
   }
   return false;
 }
+
+static const rmw_time_t deadline_default = RMW_QOS_DEADLINE_DEFAULT;
+static const rmw_time_t deadline_best_available = RMW_QOS_DEADLINE_BEST_AVAILABLE;
+static const rmw_time_t liveliness_lease_duration_default =
+  RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+static const rmw_time_t liveliness_lease_duration_best_available =
+  RMW_QOS_LIVELINESS_LEASE_DURATION_BEST_AVAILABLE;
 
 // Returns RMW_RET_OK if successful or no buffer was provided
 // Returns RMW_RET_ERROR if there as an error copying the message to the buffer
@@ -127,7 +135,6 @@ qos_profile_check_compatible(
 
   const rmw_time_t & pub_deadline = publisher_qos.deadline;
   const rmw_time_t & sub_deadline = subscription_qos.deadline;
-  const rmw_time_t deadline_default = RMW_QOS_DEADLINE_DEFAULT;
 
   // No deadline for publisher and deadline for subscription
   if (pub_deadline == deadline_default && sub_deadline != deadline_default) {
@@ -171,10 +178,11 @@ qos_profile_check_compatible(
 
   const rmw_time_t & pub_lease = publisher_qos.liveliness_lease_duration;
   const rmw_time_t & sub_lease = subscription_qos.liveliness_lease_duration;
-  const rmw_time_t lease_default = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
 
   // No lease duration for publisher and lease duration for subscription
-  if (pub_lease == lease_default && sub_lease != lease_default) {
+  if (pub_lease == liveliness_lease_duration_default &&
+    sub_lease != liveliness_lease_duration_default)
+  {
     *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
     rmw_ret_t append_ret = _append_to_buffer(
       reason,
@@ -186,7 +194,9 @@ qos_profile_check_compatible(
   }
 
   // Subscription lease duration is less than publisher lease duration
-  if (pub_lease != lease_default && sub_lease != lease_default) {
+  if (pub_lease != liveliness_lease_duration_default &&
+    sub_lease != liveliness_lease_duration_default)
+  {
     if (sub_lease < pub_lease) {
       *compatibility = RMW_QOS_COMPATIBILITY_ERROR;
       rmw_ret_t append_ret = _append_to_buffer(
@@ -371,6 +381,264 @@ qos_profile_check_compatible(
     }
   }
 
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+qos_profile_get_best_available_for_subscription(
+  const rmw_topic_endpoint_info_array_t * publishers_info,
+  rmw_qos_profile_t * subscription_profile)
+{
+  if (!publishers_info) {
+    RMW_SET_ERROR_MSG("publishers_info parameter is null");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (!subscription_profile) {
+    RMW_SET_ERROR_MSG("subscription_profile parameter is null");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  // Only use "reliable" reliability if all publisher profiles are reliable
+  // Only use "transient local" durability if all publisher profiles are transient local
+  // Only use "manual by topic" liveliness if all publisher profiles are manual by topic
+  // Use default deadline if all publishers have default deadline, otherwise use largest deadline
+  // Use default lease duration if all publishers have default lease, otherwise use largest lease
+  size_t number_of_reliable = 0u;
+  size_t number_of_transient_local = 0u;
+  size_t number_of_manual_by_topic = 0u;
+  bool use_default_deadline = true;
+  rmw_time_t largest_deadline = {0u, 0u};
+  bool use_default_liveliness_lease_duration = true;
+  rmw_time_t largest_liveliness_lease_duration = {0u, 0u};
+  for (size_t i = 0u; i < publishers_info->size; ++i) {
+    const rmw_qos_profile_t & profile = publishers_info->info_array[i].qos_profile;
+    if (RMW_QOS_POLICY_RELIABILITY_RELIABLE == profile.reliability) {
+      number_of_reliable++;
+    }
+    if (RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL == profile.durability) {
+      number_of_transient_local++;
+    }
+    if (RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC == profile.liveliness) {
+      number_of_manual_by_topic++;
+    }
+    if (profile.deadline != deadline_default) {
+      use_default_deadline = false;
+      if (largest_deadline < profile.deadline) {
+        largest_deadline = profile.deadline;
+      }
+    }
+    if (profile.liveliness_lease_duration != liveliness_lease_duration_default) {
+      use_default_liveliness_lease_duration = false;
+      if (largest_liveliness_lease_duration < profile.liveliness_lease_duration) {
+        largest_liveliness_lease_duration = profile.liveliness_lease_duration;
+      }
+    }
+  }
+
+  if (RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE == subscription_profile->reliability) {
+    if (number_of_reliable == publishers_info->size) {
+      subscription_profile->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+    } else {
+      subscription_profile->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
+    }
+  }
+
+  if (RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE == subscription_profile->durability) {
+    if (number_of_transient_local == publishers_info->size) {
+      subscription_profile->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+    } else {
+      subscription_profile->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
+    }
+  }
+
+  if (RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE == subscription_profile->liveliness) {
+    if (number_of_manual_by_topic == publishers_info->size) {
+      subscription_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    } else {
+      subscription_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    }
+  }
+
+  if (deadline_best_available == subscription_profile->deadline) {
+    if (use_default_deadline) {
+      subscription_profile->deadline = RMW_QOS_DEADLINE_DEFAULT;
+    } else {
+      subscription_profile->deadline = largest_deadline;
+    }
+  }
+
+  if (liveliness_lease_duration_best_available == subscription_profile->liveliness_lease_duration) {
+    if (use_default_liveliness_lease_duration) {
+      subscription_profile->liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+    } else {
+      subscription_profile->liveliness_lease_duration = largest_liveliness_lease_duration;
+    }
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+qos_profile_get_best_available_for_publisher(
+  const rmw_topic_endpoint_info_array_t * subscriptions_info,
+  rmw_qos_profile_t * publisher_profile)
+{
+  if (!subscriptions_info) {
+    RMW_SET_ERROR_MSG("subscriptions_info parameter is null");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  if (!publisher_profile) {
+    RMW_SET_ERROR_MSG("publisher_profile parameter is null");
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+
+  // Always use "reliable" reliability and "transient_local" durability since both policies
+  // are compatible with all subscriptions and have highest level of service
+  if (RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE == publisher_profile->reliability) {
+    publisher_profile->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  }
+  if (RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE == publisher_profile->durability) {
+    publisher_profile->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  }
+
+  // Only use "manual by topic" liveliness if at least one  subscription is using manual by topic
+  // Use default deadline if all subscriptions have default deadline, otherwise use smallest
+  // Use default lease duration if all subscriptions have default lease, otherwise use smallest
+  bool use_manual_by_topic = false;
+  bool use_default_deadline = true;
+  rmw_time_t smallest_deadline = RMW_DURATION_INFINITE;
+  bool use_default_liveliness_lease_duration = true;
+  rmw_time_t smallest_liveliness_lease_duration = RMW_DURATION_INFINITE;
+  for (size_t i = 0u; i < subscriptions_info->size; ++i) {
+    const rmw_qos_profile_t & profile = subscriptions_info->info_array[i].qos_profile;
+    if (RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC == profile.liveliness) {
+      use_manual_by_topic = true;
+    }
+    if (profile.deadline != deadline_default) {
+      use_default_deadline = false;
+      if (profile.deadline < smallest_deadline) {
+        smallest_deadline = profile.deadline;
+      }
+    }
+    if (profile.liveliness_lease_duration != liveliness_lease_duration_default) {
+      use_default_liveliness_lease_duration = false;
+      if (profile.liveliness_lease_duration < smallest_liveliness_lease_duration) {
+        smallest_liveliness_lease_duration = profile.liveliness_lease_duration;
+      }
+    }
+  }
+
+  if (RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE == publisher_profile->liveliness) {
+    if (use_manual_by_topic) {
+      publisher_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
+    } else {
+      publisher_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+    }
+  }
+
+  if (deadline_best_available == publisher_profile->deadline) {
+    if (use_default_deadline) {
+      publisher_profile->deadline = RMW_QOS_DEADLINE_DEFAULT;
+    } else {
+      publisher_profile->deadline = smallest_deadline;
+    }
+  }
+
+  if (liveliness_lease_duration_best_available == publisher_profile->liveliness_lease_duration) {
+    if (use_default_liveliness_lease_duration) {
+      publisher_profile->liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+    } else {
+      publisher_profile->liveliness_lease_duration = smallest_liveliness_lease_duration;
+    }
+  }
+
+  return RMW_RET_OK;
+}
+
+static bool
+_qos_profile_has_best_available_policy(const rmw_qos_profile_t & qos_profile)
+{
+  if (RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE == qos_profile.reliability) {
+    return true;
+  }
+  if (RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE == qos_profile.durability) {
+    return true;
+  }
+  if (RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE == qos_profile.liveliness) {
+    return true;
+  }
+  if (deadline_best_available == qos_profile.deadline) {
+    return true;
+  }
+  if (liveliness_lease_duration_best_available == qos_profile.liveliness_lease_duration) {
+    return true;
+  }
+  return false;
+}
+
+rmw_ret_t
+qos_profile_get_best_available_for_topic_subscription(
+  const rmw_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * qos_profile,
+  GetEndpointInfoByTopicFunction get_endpoint_info)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_profile, RMW_RET_INVALID_ARGUMENT);
+
+  if (_qos_profile_has_best_available_policy(*qos_profile)) {
+    rcutils_allocator_t & allocator = node->context->options.allocator;
+    rmw_topic_endpoint_info_array_t publishers_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t ret = get_endpoint_info(
+      node, &allocator, topic_name, false, &publishers_info);
+    if (RMW_RET_OK != ret) {
+      return ret;
+    }
+    ret = qos_profile_get_best_available_for_subscription(
+      &publishers_info, qos_profile);
+    rmw_ret_t fini_ret = rmw_topic_endpoint_info_array_fini(&publishers_info, &allocator);
+    if (RMW_RET_OK != fini_ret) {
+      return fini_ret;
+    }
+    if (RMW_RET_OK != ret) {
+      return ret;
+    }
+  }
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+qos_profile_get_best_available_for_topic_publisher(
+  const rmw_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * qos_profile,
+  GetEndpointInfoByTopicFunction get_endpoint_info)
+{
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_profile, RMW_RET_INVALID_ARGUMENT);
+
+  if (_qos_profile_has_best_available_policy(*qos_profile)) {
+    rcutils_allocator_t & allocator = node->context->options.allocator;
+    rmw_topic_endpoint_info_array_t subscriptions_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t ret = get_endpoint_info(
+      node, &allocator, topic_name, false, &subscriptions_info);
+    if (RMW_RET_OK != ret) {
+      return ret;
+    }
+    ret = qos_profile_get_best_available_for_publisher(
+      &subscriptions_info, qos_profile);
+    rmw_ret_t fini_ret = rmw_topic_endpoint_info_array_fini(&subscriptions_info, &allocator);
+    if (RMW_RET_OK != fini_ret) {
+      return fini_ret;
+    }
+    if (RMW_RET_OK != ret) {
+      return ret;
+    }
+  }
   return RMW_RET_OK;
 }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -642,4 +642,26 @@ qos_profile_get_best_available_for_topic_publisher(
   return RMW_RET_OK;
 }
 
+rmw_qos_profile_t
+qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile)
+{
+  rmw_qos_profile_t result = qos_profile;
+  if (RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE == result.reliability) {
+    result.reliability = rmw_qos_profile_services_default.reliability;
+  }
+  if (RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE == result.durability) {
+    result.durability = rmw_qos_profile_services_default.durability;
+  }
+  if (RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE == result.liveliness) {
+    result.liveliness = rmw_qos_profile_services_default.liveliness;
+  }
+  if (deadline_best_available == result.deadline) {
+    result.deadline = rmw_qos_profile_services_default.deadline;
+  }
+  if (liveliness_lease_duration_best_available == result.liveliness_lease_duration) {
+    result.liveliness_lease_duration = rmw_qos_profile_services_default.liveliness_lease_duration;
+  }
+  return result;
+}
+
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -16,7 +16,9 @@
 
 #include <cstring>
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rmw/types.h"
+#include "rmw/qos_profiles.h"
 
 #include "rmw_dds_common/qos.hpp"
 
@@ -753,6 +755,290 @@ TEST(test_qos, test_qos_profile_check_compatible_invalid)
     rmw_qos_profile_t sub_qos = get_qos_profile_fixture();
     rmw_ret_t ret = rmw_dds_common::qos_profile_check_compatible(
       pub_qos, sub_qos, &compatible, nullptr, 3u);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
+}
+
+TEST(test_qos, test_qos_profile_get_best_available_for_subscription)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Zero publisher endpoints
+  {
+    rmw_topic_endpoint_info_array_t zeroed_publishers_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_qos_profile_t subscription_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      &zeroed_publishers_info, &subscription_profile);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(subscription_profile.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(subscription_profile.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(subscription_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC);
+    EXPECT_TRUE(
+      rmw_time_equal(
+        subscription_profile.liveliness_lease_duration,
+        RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT));
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.deadline, RMW_QOS_DEADLINE_DEFAULT));
+  }
+  // One publisher endpoint
+  {
+    rmw_topic_endpoint_info_array_t publishers_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+      &publishers_info, 1u, &allocator);
+    ASSERT_EQ(init_ret, RMW_RET_OK);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(rmw_topic_endpoint_info_array_fini(&publishers_info, &allocator), RMW_RET_OK);
+    });
+
+    publishers_info.info_array[0].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+      RMW_QOS_DEADLINE_DEFAULT,
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
+      RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+      false
+    };
+    rmw_qos_profile_t subscription_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      &publishers_info, &subscription_profile);
+
+    EXPECT_EQ(ret, RMW_RET_OK);
+    // Expect changes to match publisher QoS
+    const rmw_qos_profile_t & publisher_profile = publishers_info.info_array[0].qos_profile;
+    EXPECT_EQ(subscription_profile.reliability, publisher_profile.reliability);
+    EXPECT_EQ(subscription_profile.durability, publisher_profile.durability);
+    EXPECT_EQ(subscription_profile.liveliness, publisher_profile.liveliness);
+    EXPECT_TRUE(
+      rmw_time_equal(
+        subscription_profile.liveliness_lease_duration,
+        publisher_profile.liveliness_lease_duration));
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.deadline, publisher_profile.deadline));
+  }
+  // More than one publisher endpoint
+  {
+    rmw_topic_endpoint_info_array_t publishers_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+      &publishers_info, 3u, &allocator);
+    ASSERT_EQ(init_ret, RMW_RET_OK);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(rmw_topic_endpoint_info_array_fini(&publishers_info, &allocator), RMW_RET_OK);
+    });
+
+    publishers_info.info_array[0].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+      RMW_QOS_DEADLINE_DEFAULT,
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,  // should result in "automatic" for subscription
+      {1u, 0u},
+      false
+    };
+    publishers_info.info_array[1].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,  // should result in "best effort" for subscription
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+      {3u, 0u},  // this deadline should appear in subscription QoS because it is the largest
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
+      RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+      false
+    };
+    publishers_info.info_array[2].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE,  // should result in "volatile" for subscription
+      {2u, 0u},
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
+      {2u, 0u},  // should appear in subscription QoS because it is the largest
+      false
+    };
+    rmw_qos_profile_t subscription_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      &publishers_info, &subscription_profile);
+
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(subscription_profile.reliability, RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+    EXPECT_EQ(subscription_profile.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(subscription_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_AUTOMATIC);
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.liveliness_lease_duration, {2u, 0u}));
+    EXPECT_TRUE(rmw_time_equal(subscription_profile.deadline, {3u, 0u}));
+  }
+}
+
+TEST(test_qos, test_qos_profile_get_best_available_for_subscription_invalid_arguments)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rmw_topic_endpoint_info_array_t publishers_info =
+    rmw_get_zero_initialized_topic_endpoint_info_array();
+  rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+    &publishers_info, 1u, &allocator);
+  ASSERT_EQ(init_ret, RMW_RET_OK);
+  rmw_qos_profile_t subscription_profile = rmw_qos_profile_best_available;
+
+  // NULL publishers_info
+  {
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      nullptr, &subscription_profile);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
+  // NULL subscription profile
+  {
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      &publishers_info, nullptr);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
+}
+
+TEST(test_qos, test_qos_profile_get_best_available_for_publisher)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  // Zero subscription endpoints
+  {
+    rmw_topic_endpoint_info_array_t zeroed_subscriptions_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_qos_profile_t publisher_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_publisher(
+      &zeroed_subscriptions_info, &publisher_profile);
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(publisher_profile.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(publisher_profile.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(publisher_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_AUTOMATIC);
+    EXPECT_TRUE(
+      rmw_time_equal(
+        publisher_profile.liveliness_lease_duration,
+        RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT));
+    EXPECT_TRUE(rmw_time_equal(publisher_profile.deadline, RMW_QOS_DEADLINE_DEFAULT));
+  }
+  // One subscription endpoint
+  {
+    rmw_topic_endpoint_info_array_t subscriptions_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+      &subscriptions_info, 1u, &allocator);
+    ASSERT_EQ(init_ret, RMW_RET_OK);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(rmw_topic_endpoint_info_array_fini(&subscriptions_info, &allocator), RMW_RET_OK);
+    });
+
+    subscriptions_info.info_array[0].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,
+      RMW_QOS_DEADLINE_DEFAULT,
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,
+      RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+      false
+    };
+    rmw_qos_profile_t publisher_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_publisher(
+      &subscriptions_info, &publisher_profile);
+
+    EXPECT_EQ(ret, RMW_RET_OK);
+    // Expect changes to match subscription QoS
+    const rmw_qos_profile_t & subscription_profile = subscriptions_info.info_array[0].qos_profile;
+    EXPECT_EQ(publisher_profile.reliability, subscription_profile.reliability);
+    EXPECT_EQ(publisher_profile.durability, subscription_profile.durability);
+    EXPECT_EQ(publisher_profile.liveliness, subscription_profile.liveliness);
+    EXPECT_TRUE(
+      rmw_time_equal(
+        publisher_profile.liveliness_lease_duration,
+        subscription_profile.liveliness_lease_duration));
+    EXPECT_TRUE(rmw_time_equal(publisher_profile.deadline, subscription_profile.deadline));
+  }
+  // More than one subscription endpoint
+  {
+    rmw_topic_endpoint_info_array_t subscriptions_info =
+      rmw_get_zero_initialized_topic_endpoint_info_array();
+    rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+      &subscriptions_info, 3u, &allocator);
+    ASSERT_EQ(init_ret, RMW_RET_OK);
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
+      EXPECT_EQ(rmw_topic_endpoint_info_array_fini(&subscriptions_info, &allocator), RMW_RET_OK);
+    });
+
+    subscriptions_info.info_array[0].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+      RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL,  // should result in "transient local" for pub
+      RMW_QOS_DEADLINE_DEFAULT,
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
+      {1u, 0u},  // should appear in publisher QoS because it is the smallest
+      false
+    };
+    subscriptions_info.info_array[1].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_RELIABLE,  // should result in "reliable" for publisher
+      RMW_QOS_POLICY_DURABILITY_VOLATILE,
+      {3u, 0u},
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC,  // should result in "manual by topic" for pub
+      RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT,
+      false
+    };
+    subscriptions_info.info_array[2].qos_profile = {
+      RMW_QOS_POLICY_HISTORY_KEEP_ALL,
+      1,
+      RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT,
+      RMW_QOS_POLICY_DURABILITY_VOLATILE,
+      {2u, 0u},  // this deadline should appear in publisher QoS because it is the smallest
+      RMW_QOS_LIFESPAN_DEFAULT,
+      RMW_QOS_POLICY_LIVELINESS_AUTOMATIC,
+      {2u, 0u},
+      false
+    };
+    rmw_qos_profile_t publisher_profile = rmw_qos_profile_best_available;
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_publisher(
+      &subscriptions_info, &publisher_profile);
+
+    EXPECT_EQ(ret, RMW_RET_OK);
+    EXPECT_EQ(publisher_profile.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
+    EXPECT_EQ(publisher_profile.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
+    EXPECT_EQ(publisher_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC);
+    EXPECT_TRUE(rmw_time_equal(publisher_profile.liveliness_lease_duration, {1u, 0u}));
+    EXPECT_TRUE(rmw_time_equal(publisher_profile.deadline, {2u, 0u}));
+  }
+}
+
+TEST(test_qos, test_qos_profile_get_best_available_for_publisher_invalid_arguments)
+{
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rmw_topic_endpoint_info_array_t subscriptions_info =
+    rmw_get_zero_initialized_topic_endpoint_info_array();
+  rmw_ret_t init_ret = rmw_topic_endpoint_info_array_init_with_size(
+    &subscriptions_info, 1u, &allocator);
+  ASSERT_EQ(init_ret, RMW_RET_OK);
+  rmw_qos_profile_t publisher_profile = rmw_qos_profile_best_available;
+
+  // NULL subscriptions_info
+  {
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_publisher(
+      nullptr, &publisher_profile);
+    EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
+  }
+  // NULL publisher profile
+  {
+    rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
+      &subscriptions_info, nullptr);
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
   }
 }

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -1042,3 +1042,18 @@ TEST(test_qos, test_qos_profile_get_best_available_for_publisher_invalid_argumen
     EXPECT_EQ(ret, RMW_RET_INVALID_ARGUMENT);
   }
 }
+
+TEST(test_qos, test_qos_profile_update_best_available_for_services)
+{
+  rmw_qos_profile_t input_profile = rmw_qos_profile_best_available;
+  rmw_qos_profile_t output_profile =
+    rmw_dds_common::qos_profile_update_best_available_for_services(input_profile);
+  EXPECT_EQ(rmw_qos_profile_services_default.reliability, output_profile.reliability);
+  EXPECT_EQ(rmw_qos_profile_services_default.durability, output_profile.durability);
+  EXPECT_EQ(rmw_qos_profile_services_default.liveliness, output_profile.liveliness);
+  EXPECT_TRUE(rmw_time_equal(rmw_qos_profile_services_default.deadline, output_profile.deadline));
+  EXPECT_TRUE(
+    rmw_time_equal(
+      rmw_qos_profile_services_default.liveliness_lease_duration,
+      output_profile.liveliness_lease_duration));
+}


### PR DESCRIPTION
Connects to https://github.com/ros2/rmw/pull/320

Given a QoS profile and set of endpoints for the same topic, overwrite any policies set to
BEST_AVAILABLE with a policy such that it matches all endpoints while maintaining a high
level of service.

Add testable functions for updating BEST_AVAILABLE policies,

- qos_profile_get_best_available_for_subscription
- qos_profile_get_best_available_for_publisher

and add convenience functions that actual query the graph for RMW implementations to use,

- qos_profile_get_best_available_for_topic_subscription
- qos_profile_get_best_available_for_topic_publisher