### PR TITLE
Type hash in GraphCache, user_data encoding tools

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -109,7 +109,7 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_qos test/test_qos.cpp)
   if(TARGET test_qos)
-    target_link_libraries(test_qos ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools)
+    target_link_libraries(test_qos ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools rcpputils::rcpputils)
   endif()
 
   ament_add_gmock(test_time_utils test/test_time_utils.cpp)

--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_runtime_c REQUIRED)
 
 ament_add_default_options()
 ament_export_dependencies(ament_cmake_core)
@@ -44,7 +45,8 @@ target_link_libraries(${PROJECT_NAME}_library PUBLIC
   rcutils::rcutils
   rmw::rmw)
 target_link_libraries(${PROJECT_NAME}_library PRIVATE
-  rcpputils::rcpputils)
+  rcpputils::rcpputils
+  rosidl_runtime_c::rosidl_runtime_c)
 target_include_directories(${PROJECT_NAME}_library
   PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
@@ -95,7 +97,8 @@ if(BUILD_TESTING)
 
   ament_add_gmock(test_graph_cache test/test_graph_cache.cpp)
   if(TARGET test_graph_cache)
-    target_link_libraries(test_graph_cache ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools)
+    target_link_libraries(test_graph_cache
+      ${PROJECT_NAME}_library osrf_testing_tools_cpp::memory_tools rosidl_runtime_c::rosidl_runtime_c)
     target_compile_definitions(test_graph_cache PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
@@ -123,7 +126,7 @@ if(BUILD_TESTING)
 
   add_performance_test(benchmark_graph_cache test/benchmark/benchmark_graph_cache.cpp)
   if(TARGET benchmark_graph_cache)
-    target_link_libraries(benchmark_graph_cache ${PROJECT_NAME}_library)
+    target_link_libraries(benchmark_graph_cache ${PROJECT_NAME}_library rosidl_runtime_c::rosidl_runtime_c)
   endif()
 endif()
 

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -566,6 +566,11 @@ struct EntityInfo
     participant_gid(participant_gid),
     qos(qos)
   {
+    RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+      topic_type_hash_,
+      "Type hash cannot be null",
+      throw std::runtime_error("Type hash cannot be null."));
+    RCUTILS_LOG_WARN("EntityInfo ctor, type hash %p", topic_type_hash_);
     memcpy(topic_type_hash, topic_type_hash_, RCUTILS_SHA256_BLOCK_SIZE);
   }
 };

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -24,7 +24,6 @@
 #include <vector>
 
 #include "rcutils/logging_macros.h"
-#include "rcutils/sha256.h"
 
 #include "rmw/names_and_types.h"
 #include "rmw/topic_endpoint_info.h"
@@ -95,7 +94,7 @@ public:
     const rmw_gid_t & writer_gid,
     const std::string & topic_name,
     const std::string & type_name,
-    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+    const rosidl_type_hash_t & type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -115,7 +114,7 @@ public:
     const rmw_gid_t & reader_gid,
     const std::string & topic_name,
     const std::string & type_name,
-    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+    const rosidl_type_hash_t & type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -136,7 +135,7 @@ public:
     const rmw_gid_t & gid,
     const std::string & topic_name,
     const std::string & type_name,
-    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+    const rosidl_type_hash_t & type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
     bool is_reader);
@@ -545,10 +544,10 @@ struct EntityInfo
 {
   /// Topic name.
   std::string topic_name;
-  /// Topic type.
+  /// Topic type name.
   std::string topic_type;
   /// Topic type hash.
-  uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE];
+  rosidl_type_hash_t topic_type_hash;
   /// Participant gid.
   rmw_gid_t participant_gid;
   /// Quality of service of the topic.
@@ -558,20 +557,15 @@ struct EntityInfo
   EntityInfo(
     const std::string & topic_name,
     const std::string & topic_type,
-    const uint8_t topic_type_hash_[RCUTILS_SHA256_BLOCK_SIZE],
+    const rosidl_type_hash_t & topic_type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos)
   : topic_name(topic_name),
     topic_type(topic_type),
+    topic_type_hash(topic_type_hash),
     participant_gid(participant_gid),
     qos(qos)
-  {
-    RCUTILS_CHECK_FOR_NULL_WITH_MSG(
-      topic_type_hash_,
-      "Type hash cannot be null",
-      throw std::runtime_error("Type hash cannot be null."));
-    memcpy(topic_type_hash, topic_type_hash_, RCUTILS_SHA256_BLOCK_SIZE);
-  }
+  {}
 };
 
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "rcutils/logging_macros.h"
+#include "rcutils/sha256.h"
 
 #include "rmw/names_and_types.h"
 #include "rmw/topic_endpoint_info.h"
@@ -94,6 +95,7 @@ public:
     const rmw_gid_t & writer_gid,
     const std::string & topic_name,
     const std::string & type_name,
+    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -113,6 +115,7 @@ public:
     const rmw_gid_t & reader_gid,
     const std::string & topic_name,
     const std::string & type_name,
+    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -133,6 +136,7 @@ public:
     const rmw_gid_t & gid,
     const std::string & topic_name,
     const std::string & type_name,
+    const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
     bool is_reader);
@@ -543,6 +547,8 @@ struct EntityInfo
   std::string topic_name;
   /// Topic type.
   std::string topic_type;
+  /// Topic type hash.
+  uint8_t topic_type_hash[RCUTILS_SHA256_BLOCK_SIZE];
   /// Participant gid.
   rmw_gid_t participant_gid;
   /// Quality of service of the topic.
@@ -552,13 +558,16 @@ struct EntityInfo
   EntityInfo(
     const std::string & topic_name,
     const std::string & topic_type,
+    const uint8_t topic_type_hash_[RCUTILS_SHA256_BLOCK_SIZE],
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos)
   : topic_name(topic_name),
     topic_type(topic_type),
     participant_gid(participant_gid),
     qos(qos)
-  {}
+  {
+    memcpy(topic_type_hash, topic_type_hash_, RCUTILS_SHA256_BLOCK_SIZE);
+  }
 };
 
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -189,7 +189,6 @@ public:
     const rmw_qos_profile_t & qos,
     bool is_reader);
 
-
   /// Remove a data writer.
   /**
    * \param gid GUID of the data writer.

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -78,7 +78,7 @@ public:
    * @{
    */
 
-  /// Add a data writer.
+  /// Add a data writer based on discovery.
   /**
    * \param writer_gid GUID of the data writer.
    * \param topic_name Name of the DDS topic for this data writer.
@@ -96,6 +96,21 @@ public:
     const std::string & topic_name,
     const std::string & type_name,
     const rosidl_type_hash_t & type_hash,
+    const rmw_gid_t & participant_gid,
+    const rmw_qos_profile_t & qos);
+
+  /// Add a data writer based on discovery.
+  /**
+   * See add_reader with rosidl_type_hash_t, whose other parameters match these.
+   */
+  RMW_DDS_COMMON_PUBLIC
+    RCUTILS_DEPRECATED_WITH_MSG(
+    "Migrate to using the version of this function taking a type hash.")
+  bool
+  add_writer(
+    const rmw_gid_t & writer_gid,
+    const std::string & topic_name,
+    const std::string & type_name,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -117,6 +132,21 @@ public:
     const std::string & topic_name,
     const std::string & type_name,
     const rosidl_type_hash_t & type_hash,
+    const rmw_gid_t & participant_gid,
+    const rmw_qos_profile_t & qos);
+
+  /// Add a data reader based on discovery.
+  /**
+   * See add_reader with rosidl_type_hash_t, whose other parameters match these.
+   */
+  RMW_DDS_COMMON_PUBLIC
+    RCUTILS_DEPRECATED_WITH_MSG(
+    "Migrate to using the version of this function taking a type hash.")
+  bool
+  add_reader(
+    const rmw_gid_t & reader_gid,
+    const std::string & topic_name,
+    const std::string & type_name,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -142,6 +172,23 @@ public:
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
     bool is_reader);
+
+  /// Add a data reader or writer.
+  /**
+   * See add_entity with rosidl_type_hash_t, whose other parameters match these.
+   */
+  RMW_DDS_COMMON_PUBLIC
+    RCUTILS_DEPRECATED_WITH_MSG(
+    "Migrate to using the version of this function taking a type hash.")
+  bool
+  add_entity(
+    const rmw_gid_t & gid,
+    const std::string & topic_name,
+    const std::string & type_name,
+    const rmw_gid_t & participant_gid,
+    const rmw_qos_profile_t & qos,
+    bool is_reader);
+
 
   /// Remove a data writer.
   /**

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -83,6 +83,7 @@ public:
    * \param writer_gid GUID of the data writer.
    * \param topic_name Name of the DDS topic for this data writer.
    * \param type_name Type name of the DDS topic for this data writer.
+   * \param type_hash Hash of the description of the topic type.
    * \param participant_gid GUID of the participant.
    * \param qos QoS profile of the data writer.
    * \return `true` if the cache was updated, `false` if the data writer
@@ -103,6 +104,7 @@ public:
    * \param reader_gid GUID of the The data reader.
    * \param topic_name Name of the DDS topic for this data reader.
    * \param type_name Type name of the DDS topic for this data reader.
+   * \param type_hash Hash of the description of the topic type.
    * \param participant_gid GUID of the participant.
    * \param qos QoS profile of the data reader.
    * \return `true` if the cache was updated, `false` if the data reader
@@ -123,6 +125,7 @@ public:
    * \param gid GUID of the entity.
    * \param topic_name Name of the DDS topic for this data reader.
    * \param type_name Type name of the DDS topic for this entity
+   * \param type_hash Hash of the description of the topic type.
    * \param participant_gid GUID of the participant.
    * \param qos QoS profile of the entity.
    * \param is_reader Whether the entity is a data reader or a writer.

--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -570,7 +570,6 @@ struct EntityInfo
       topic_type_hash_,
       "Type hash cannot be null",
       throw std::runtime_error("Type hash cannot be null."));
-    RCUTILS_LOG_WARN("EntityInfo ctor, type hash %p", topic_type_hash_);
     memcpy(topic_type_hash, topic_type_hash_, RCUTILS_SHA256_BLOCK_SIZE);
   }
 };

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -16,6 +16,7 @@
 #define RMW_DDS_COMMON__QOS_HPP_
 
 #include <functional>
+#include <vector>
 
 #include "rmw/qos_profiles.h"
 #include "rmw/topic_endpoint_info_array.h"
@@ -223,6 +224,27 @@ qos_profile_get_best_available_for_topic_publisher(
 RMW_DDS_COMMON_PUBLIC
 rmw_qos_profile_t
 qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile);
+
+/// TODO(emersonknapp)
+/**
+ * TODO(emersonknapp)
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+parse_type_hash_from_user_data_qos(
+  const uint8_t * user_data,
+  size_t user_data_size,
+  uint8_t out_type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
+
+/// TODO(emersonknapp)
+/**
+ * TODO(emersonknapp)
+ */
+RMW_DDS_COMMON_PUBLIC
+rmw_ret_t
+encode_type_hash_for_user_data_qos(
+  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+  std::vector<uint8_t> & out_data);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -16,6 +16,7 @@
 #define RMW_DDS_COMMON__QOS_HPP_
 
 #include <functional>
+#include <string>
 #include <vector>
 
 #include "rmw/qos_profiles.h"
@@ -241,10 +242,8 @@ parse_type_hash_from_user_data_qos(
  * TODO(emersonknapp)
  */
 RMW_DDS_COMMON_PUBLIC
-rmw_ret_t
-encode_type_hash_for_user_data_qos(
-  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
-  std::vector<uint8_t> & out_data);
+std::string
+encode_type_hash_for_user_data_qos(const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -17,7 +17,6 @@
 
 #include <functional>
 #include <string>
-#include <vector>
 
 #include "rmw/qos_profiles.h"
 #include "rmw/topic_endpoint_info_array.h"
@@ -226,27 +225,34 @@ RMW_DDS_COMMON_PUBLIC
 rmw_qos_profile_t
 qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile);
 
-/// Parse USER_DATA key=value;key=value; encoding, find value of key "typehash"
+/// Parse USER_DATA "key=value;key=value;"" encoding, finding value of key "typehash"
 /**
  * \param[in] user_data USER_DATA qos raw bytes
  * \param[in] user_data_size Length of user_data
- * \return Parsed type hash
- * \return zero-initialized value if data unparseable or key not found
+ * \param[out] type_hash_out Filled with type hash data if found, or to zero value if key not found
+ * \return RMW_RET_OK if key parsed successfully, or if key not found
+ * \return RMW_RET_ERROR if typehash key found, but value could not be parsed
  */
 RMW_DDS_COMMON_PUBLIC
-rosidl_type_hash_t
+rmw_ret_t
 parse_type_hash_from_user_data(
   const uint8_t * user_data,
-  size_t user_data_size);
+  size_t user_data_size,
+  rosidl_type_hash_t & type_hash_out);
 
-/// Encode type hash as "typehash=hash_string;"
+/// Encode type hash as "typehash=hash_string;" for use in USER_DATA QoS
 /**
  * \param[in] type_hash Type hash value to encode
- * \return A substring in key=value; format that can be appended to QoS USER_DATA
+ * \param[out] string_out On success, will be set to "typehash=stringified_type_hash;"
+ *   If type_hash's version is 0, string_out will be set to empty
+ * \return RMW_RET_OK on success, including empty string for unset version
+ * \return RMW_RET_BAD_ALLOC if memory allocation fails
  */
 RMW_DDS_COMMON_PUBLIC
-std::string
-encode_type_hash_for_user_data_qos(const rosidl_type_hash_t & type_hash);
+rmw_ret_t
+encode_type_hash_for_user_data_qos(
+  const rosidl_type_hash_t & type_hash,
+  std::string & string_out);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -231,6 +231,7 @@ qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_pro
  * \param[in] user_data_size Length of user_data
  * \param[out] type_hash_out Filled with type hash data if found, or to zero value if key not found
  * \return RMW_RET_OK if key parsed successfully, or if key not found
+ * \return RMW_RET_INVALID_ARGUMENT if user_data is null
  * \return RMW_RET_ERROR if typehash key found, but value could not be parsed
  */
 RMW_DDS_COMMON_PUBLIC

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -226,19 +226,20 @@ RMW_DDS_COMMON_PUBLIC
 rmw_qos_profile_t
 qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile);
 
-/// Parse the standard USER_DATA key=value;key=value; encoding, and find typehash
+/// Parse USER_DATA key=value;key=value; encoding, find value of key "typehash"
 /**
  * \param[in] user_data USER_DATA qos raw bytes
  * \param[in] user_data_size Length of user_data
- * \return Parsed type hash, may be zero-initialized unset value if data couldn't be parsed
+ * \return Parsed type hash
+ * \return zero-initialized value if data unparseable or key not found
  */
 RMW_DDS_COMMON_PUBLIC
 rosidl_type_hash_t
-parse_type_hash_from_user_data_qos(
+parse_type_hash_from_user_data(
   const uint8_t * user_data,
   size_t user_data_size);
 
-/// Encode a type hash as standardized USER_DATA key=value; substring
+/// Encode type hash as "typehash=hash_string;"
 /**
  * \param[in] type_hash Type hash value to encode
  * \return A substring in key=value; format that can be appended to QoS USER_DATA

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -231,11 +231,10 @@ qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_pro
  * TODO(emersonknapp)
  */
 RMW_DDS_COMMON_PUBLIC
-rmw_ret_t
+rosidl_type_hash_t
 parse_type_hash_from_user_data_qos(
   const uint8_t * user_data,
-  size_t user_data_size,
-  uint8_t out_type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
+  size_t user_data_size);
 
 /// TODO(emersonknapp)
 /**
@@ -243,7 +242,7 @@ parse_type_hash_from_user_data_qos(
  */
 RMW_DDS_COMMON_PUBLIC
 std::string
-encode_type_hash_for_user_data_qos(const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE]);
+encode_type_hash_for_user_data_qos(const rosidl_type_hash_t & type_hash);
 
 }  // namespace rmw_dds_common
 

--- a/rmw_dds_common/include/rmw_dds_common/qos.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/qos.hpp
@@ -226,9 +226,11 @@ RMW_DDS_COMMON_PUBLIC
 rmw_qos_profile_t
 qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_profile);
 
-/// TODO(emersonknapp)
+/// Parse the standard USER_DATA key=value;key=value; encoding, and find typehash
 /**
- * TODO(emersonknapp)
+ * \param[in] user_data USER_DATA qos raw bytes
+ * \param[in] user_data_size Length of user_data
+ * \return Parsed type hash, may be zero-initialized unset value if data couldn't be parsed
  */
 RMW_DDS_COMMON_PUBLIC
 rosidl_type_hash_t
@@ -236,9 +238,10 @@ parse_type_hash_from_user_data_qos(
   const uint8_t * user_data,
   size_t user_data_size);
 
-/// TODO(emersonknapp)
+/// Encode a type hash as standardized USER_DATA key=value; substring
 /**
- * TODO(emersonknapp)
+ * \param[in] type_hash Type hash value to encode
+ * \return A substring in key=value; format that can be appended to QoS USER_DATA
  */
 RMW_DDS_COMMON_PUBLIC
 std::string

--- a/rmw_dds_common/package.xml
+++ b/rmw_dds_common/package.xml
@@ -20,6 +20,7 @@
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>
+  <depend>rosidl_runtime_c</depend>
   <depend>rosidl_runtime_cpp</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -67,7 +67,7 @@ GraphCache::add_writer(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
-  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+  const rosidl_type_hash_t & type_hash,
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos)
 {
@@ -85,7 +85,7 @@ GraphCache::add_reader(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
-  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+  const rosidl_type_hash_t & type_hash,
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos)
 {
@@ -103,7 +103,7 @@ GraphCache::add_entity(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
-  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
+  const rosidl_type_hash_t & type_hash,
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos,
   bool is_reader)
@@ -577,7 +577,7 @@ __get_entities_info_by_topic(
 
     ret = rmw_topic_endpoint_info_set_topic_type_hash(
       &endpoint_info,
-      entity_pair.second.topic_type_hash);
+      &entity_pair.second.topic_type_hash);
     if (RMW_RET_OK != ret) {
       return ret;
     }

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -67,6 +67,7 @@ GraphCache::add_writer(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
+  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos)
 {
@@ -74,7 +75,7 @@ GraphCache::add_writer(
   auto pair = data_writers_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(gid),
-    std::forward_as_tuple(topic_name, type_name, participant_gid, qos));
+    std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
   GRAPH_CACHE_CALL_ON_CHANGE_CALLBACK_IF(this, pair.second);
   return pair.second;
 }
@@ -84,6 +85,7 @@ GraphCache::add_reader(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
+  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos)
 {
@@ -91,7 +93,7 @@ GraphCache::add_reader(
   auto pair = data_readers_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(gid),
-    std::forward_as_tuple(topic_name, type_name, participant_gid, qos));
+    std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
   GRAPH_CACHE_CALL_ON_CHANGE_CALLBACK_IF(this, pair.second);
   return pair.second;
 }
@@ -101,6 +103,7 @@ GraphCache::add_entity(
   const rmw_gid_t & gid,
   const std::string & topic_name,
   const std::string & type_name,
+  const uint8_t type_hash[RCUTILS_SHA256_BLOCK_SIZE],
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos,
   bool is_reader)
@@ -110,6 +113,7 @@ GraphCache::add_entity(
       gid,
       topic_name,
       type_name,
+      type_hash,
       participant_gid,
       qos);
   }
@@ -117,6 +121,7 @@ GraphCache::add_entity(
     gid,
     topic_name,
     type_name,
+    type_hash,
     participant_gid,
     qos);
 }

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -575,6 +575,13 @@ __get_entities_info_by_topic(
       return ret;
     }
 
+    ret = rmw_topic_endpoint_info_set_topic_type_hash(
+      &endpoint_info,
+      entity_pair.second.topic_type_hash);
+    if (RMW_RET_OK != ret) {
+      return ret;
+    }
+
     ret = rmw_topic_endpoint_info_set_endpoint_type(
       &endpoint_info,
       is_reader ? RMW_ENDPOINT_SUBSCRIPTION : RMW_ENDPOINT_PUBLISHER);

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -81,6 +81,23 @@ GraphCache::add_writer(
 }
 
 bool
+GraphCache::add_writer(
+  const rmw_gid_t & gid,
+  const std::string & topic_name,
+  const std::string & type_name,
+  const rmw_gid_t & participant_gid,
+  const rmw_qos_profile_t & qos)
+{
+  return this->add_writer(
+    gid,
+    topic_name,
+    type_name,
+    rosidl_get_zero_initialized_type_hash(),
+    participant_gid,
+    qos);
+}
+
+bool
 GraphCache::add_reader(
   const rmw_gid_t & gid,
   const std::string & topic_name,
@@ -96,6 +113,23 @@ GraphCache::add_reader(
     std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
   GRAPH_CACHE_CALL_ON_CHANGE_CALLBACK_IF(this, pair.second);
   return pair.second;
+}
+
+bool
+GraphCache::add_reader(
+  const rmw_gid_t & gid,
+  const std::string & topic_name,
+  const std::string & type_name,
+  const rmw_gid_t & participant_gid,
+  const rmw_qos_profile_t & qos)
+{
+  return this->add_reader(
+    gid,
+    topic_name,
+    type_name,
+    rosidl_get_zero_initialized_type_hash(),
+    participant_gid,
+    qos);
 }
 
 bool
@@ -124,6 +158,25 @@ GraphCache::add_entity(
     type_hash,
     participant_gid,
     qos);
+}
+
+bool
+GraphCache::add_entity(
+  const rmw_gid_t & gid,
+  const std::string & topic_name,
+  const std::string & type_name,
+  const rmw_gid_t & participant_gid,
+  const rmw_qos_profile_t & qos,
+  bool is_reader)
+{
+  return this->add_entity(
+    gid,
+    topic_name,
+    type_name,
+    rosidl_get_zero_initialized_type_hash(),
+    participant_gid,
+    qos,
+    is_reader);
 }
 
 bool

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -678,7 +678,6 @@ parse_type_hash_from_user_data_qos(
   std::vector<uint8_t> udvec(user_data, user_data + user_data_size);
   rosidl_type_hash_t type_hash;
 
-
   auto key_value = rmw::impl::cpp::parse_key_value(udvec);
   auto typehash_it = key_value.find("typehash");
   if (typehash_it == key_value.end()) {
@@ -686,10 +685,8 @@ parse_type_hash_from_user_data_qos(
   }
   std::string type_hash_str(typehash_it->second.begin(), typehash_it->second.end());
   rosidl_parse_type_hash_string(
-    type_hash_str.data(),
-    type_hash_str.size(),
+    type_hash_str.c_str(),
     &type_hash);
-  // RCUTILS_LOG_WARN("Hi am smashy");
   return type_hash;
 }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -671,7 +671,7 @@ qos_profile_update_best_available_for_services(const rmw_qos_profile_t & qos_pro
 }
 
 rosidl_type_hash_t
-parse_type_hash_from_user_data_qos(
+parse_type_hash_from_user_data(
   const uint8_t * user_data,
   size_t user_data_size)
 {

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -705,10 +705,10 @@ encode_type_hash_for_user_data_qos(
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
     return RMW_RET_BAD_ALLOC;
   }
-  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
   if (RCUTILS_RET_OK != stringify_ret) {
     return RMW_RET_ERROR;
   }
+  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
   string_out = "typehash=" + std::string(type_hash_c_str) + ";";
   return RMW_RET_OK;
 }

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -16,12 +16,10 @@
 
 #include <cstdarg>
 #include <cstring>
-#include <iomanip>
 #include <string>
 #include <vector>
 
 #include "rcutils/error_handling.h"
-#include "rcutils/logging_macros.h"
 #include "rcutils/snprintf.h"
 #include "rmw/error_handling.h"
 #include "rmw/impl/cpp/key_value.hpp"
@@ -676,6 +674,7 @@ parse_type_hash_from_user_data(
   size_t user_data_size,
   rosidl_type_hash_t & type_hash_out)
 {
+  RMW_CHECK_ARGUMENT_FOR_NULL(user_data, RMW_RET_INVALID_ARGUMENT);
   std::vector<uint8_t> udvec(user_data, user_data + user_data_size);
   auto key_value = rmw::impl::cpp::parse_key_value(udvec);
   auto typehash_it = key_value.find("typehash");

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -683,7 +683,7 @@ parse_type_hash_from_user_data(
     return RMW_RET_OK;
   }
   std::string type_hash_str(typehash_it->second.begin(), typehash_it->second.end());
-  if (RMW_RET_OK != rosidl_parse_type_hash_string(type_hash_str.c_str(), &type_hash_out)) {
+  if (RCUTILS_RET_OK != rosidl_parse_type_hash_string(type_hash_str.c_str(), &type_hash_out)) {
     return RMW_RET_ERROR;
   }
   return RMW_RET_OK;
@@ -700,9 +700,11 @@ encode_type_hash_for_user_data_qos(
   }
   auto allocator = rcutils_get_default_allocator();
   char * type_hash_c_str = nullptr;
-  rmw_ret_t stringify_ret = rosidl_stringify_type_hash(&type_hash, allocator, &type_hash_c_str);
-  if (RCUTILS_RET_OK != stringify_ret) {
-    return stringify_ret;
+  rcutils_ret_t stringify_ret = rosidl_stringify_type_hash(&type_hash, allocator, &type_hash_c_str);
+  if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
+    return RMW_RET_BAD_ALLOC;
+  } else if (RCUTILS_RET_OK != stringify_ret) {
+    return RMW_RET_ERROR;
   }
   string_out = "typehash=" + std::string(type_hash_c_str) + ";";
   allocator.deallocate(type_hash_c_str, &allocator.state);

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "rcpputils/scope_exit.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
 #include "rmw/error_handling.h"
@@ -703,11 +704,12 @@ encode_type_hash_for_user_data_qos(
   rcutils_ret_t stringify_ret = rosidl_stringify_type_hash(&type_hash, allocator, &type_hash_c_str);
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
     return RMW_RET_BAD_ALLOC;
-  } else if (RCUTILS_RET_OK != stringify_ret) {
+  }
+  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
+  if (RCUTILS_RET_OK != stringify_ret) {
     return RMW_RET_ERROR;
   }
   string_out = "typehash=" + std::string(type_hash_c_str) + ";";
-  allocator.deallocate(type_hash_c_str, &allocator.state);
   return RMW_RET_OK;
 }
 

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -684,13 +684,13 @@ parse_type_hash_from_user_data_qos(
   auto type_hash_value = typehash_it->second;
 
   std::string type_hash_str(type_hash_value.begin(), type_hash_value.end());
-  assert(type_hash_str.size() == RCUTILS_SHA256_BLOCK_SIZE * 2);
+  assert(type_hash_str.size() == ROSIDL_TYPE_HASH_SIZE * 2);
   RCUTILS_LOG_ERROR("  - %s", type_hash_str.c_str());
 
   rosidl_type_hash_t type_hash;
   // TODO(emersonknapp) type_hash.version!
   std::istringstream iss(type_hash_str);
-  for (size_t i = 0; i < RCUTILS_SHA256_BLOCK_SIZE; i++) {
+  for (size_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
     iss >> std::hex >> type_hash.value[i];
   }
   return type_hash;
@@ -699,10 +699,15 @@ parse_type_hash_from_user_data_qos(
 std::string
 encode_type_hash_for_user_data_qos(const rosidl_type_hash_t & type_hash)
 {
+  if (type_hash.version == ROSIDL_TYPE_HASH_VERSION_UNSET) {
+    return "";
+  }
+
   std::ostringstream os;
   os << "typehash=";
+  // os << "RIHS" << type_hash.version << "_";
   // TODO(emersonknapp) version prefix
-  for (size_t i = 0; i < RCUTILS_SHA256_BLOCK_SIZE; i++) {
+  for (size_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
     os << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(type_hash.value[i]);
   }
   os << ";";

--- a/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
+++ b/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
@@ -24,6 +24,8 @@
 #include "rmw_dds_common/gid_utils.hpp"
 #include "rmw_dds_common/graph_cache.hpp"
 
+#include "rosidl_runtime_c/type_hash.h"
+
 using performance_test_fixture::PerformanceTest;
 using rmw_dds_common::GraphCache;
 

--- a/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
+++ b/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
@@ -120,6 +120,7 @@ add_entities(
       gid_from_string(elem.gid),
       elem.name,
       elem.type,
+      nullptr,
       gid_from_string(elem.participant_gid),
       rmw_qos_profile_default,
       elem.is_reader);

--- a/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
+++ b/rmw_dds_common/test/benchmark/benchmark_graph_cache.cpp
@@ -120,7 +120,7 @@ add_entities(
       gid_from_string(elem.gid),
       elem.name,
       elem.type,
-      nullptr,
+      rosidl_get_zero_initialized_type_hash(),
       gid_from_string(elem.participant_gid),
       rmw_qos_profile_default,
       elem.is_reader);

--- a/rmw_dds_common/test/test_graph_cache.cpp
+++ b/rmw_dds_common/test/test_graph_cache.cpp
@@ -303,7 +303,7 @@ add_entities(
         gid_from_string(elem.gid),
         elem.name,
         elem.type,
-        nullptr,
+        rosidl_get_zero_initialized_type_hash(),
         gid_from_string(elem.participant_gid),
         rmw_qos_profile_default,
         elem.is_reader));

--- a/rmw_dds_common/test/test_graph_cache.cpp
+++ b/rmw_dds_common/test/test_graph_cache.cpp
@@ -303,6 +303,7 @@ add_entities(
         gid_from_string(elem.gid),
         elem.name,
         elem.type,
+        nullptr,
         gid_from_string(elem.participant_gid),
         rmw_qos_profile_default,
         elem.is_reader));

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -17,6 +17,7 @@
 #include <cstring>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcpputils/scope_exit.hpp"
 #include "rmw/error_handling.h"
 #include "rmw/qos_profiles.h"
 #include "rmw/types.h"
@@ -1100,9 +1101,10 @@ TEST(test_qos, test_parse_type_hash_from_user_data)
   char * type_hash_c_str;
   auto allocator = rcutils_get_default_allocator();
   ret = rosidl_stringify_type_hash(&input_type_hash, allocator, &type_hash_c_str);
+  ASSERT_NE(ret, RCUTILS_RET_BAD_ALLOC);
+  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
   ASSERT_EQ(ret, RCUTILS_RET_OK);
   std::string type_hash_string(type_hash_c_str);
-  allocator.deallocate(type_hash_c_str, &allocator.state);
   std::string good_data = "foo=bar;typehash=" + type_hash_string + ";key=value;";
   ret = rmw_dds_common::parse_type_hash_from_user_data(
     reinterpret_cast<uint8_t *>(good_data.data()), good_data.size(), result_type_hash);

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -1101,9 +1101,8 @@ TEST(test_qos, test_parse_type_hash_from_user_data)
   char * type_hash_c_str;
   auto allocator = rcutils_get_default_allocator();
   ret = rosidl_stringify_type_hash(&input_type_hash, allocator, &type_hash_c_str);
-  ASSERT_NE(ret, RCUTILS_RET_BAD_ALLOC);
-  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
   ASSERT_EQ(ret, RCUTILS_RET_OK);
+  RCPPUTILS_SCOPE_EXIT(allocator.deallocate(type_hash_c_str, &allocator.state));
   std::string type_hash_string(type_hash_c_str);
   std::string good_data = "foo=bar;typehash=" + type_hash_string + ";key=value;";
   ret = rmw_dds_common::parse_type_hash_from_user_data(

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -1078,14 +1078,17 @@ TEST(test_qos, test_parse_type_hash_from_user_data)
   const auto zero_val = rosidl_get_zero_initialized_type_hash();
 
   std::string bad_value = "something that isn't key equals value semicolon";
-  rosidl_type_hash_t result_type_hash = rmw_dds_common::parse_type_hash_from_user_data(
-    reinterpret_cast<uint8_t *>(bad_value.data()), bad_value.size());
+  rosidl_type_hash_t result_type_hash;
+  rmw_ret_t ret = rmw_dds_common::parse_type_hash_from_user_data(
+    reinterpret_cast<uint8_t *>(bad_value.data()), bad_value.size(), result_type_hash);
+  EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_EQ(0, memcmp(&result_type_hash, &zero_val, sizeof(rosidl_type_hash_t)))
-    << "Malformed user_data should result in zero hash struct.";
+    << "Non-ros 2 user_data should result in zero hash struct.";
 
   std::string no_key = "key1=value1;key2=value2;key3=value3;";
-  result_type_hash = rmw_dds_common::parse_type_hash_from_user_data(
-    reinterpret_cast<uint8_t *>(no_key.data()), no_key.size());
+  ret = rmw_dds_common::parse_type_hash_from_user_data(
+    reinterpret_cast<uint8_t *>(no_key.data()), no_key.size(), result_type_hash);
+  EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_EQ(0, memcmp(&result_type_hash, &zero_val, sizeof(rosidl_type_hash_t)))
     << "No typehash key should result in zero hash struct.";
 
@@ -1096,27 +1099,33 @@ TEST(test_qos, test_parse_type_hash_from_user_data)
   }
   char * type_hash_c_str;
   auto allocator = rcutils_get_default_allocator();
-  rmw_ret_t ret = rosidl_stringify_type_hash(&input_type_hash, allocator, &type_hash_c_str);
+  ret = rosidl_stringify_type_hash(&input_type_hash, allocator, &type_hash_c_str);
   ASSERT_EQ(ret, RCUTILS_RET_OK);
   std::string type_hash_string(type_hash_c_str);
   allocator.deallocate(type_hash_c_str, &allocator.state);
   std::string good_data = "foo=bar;typehash=" + type_hash_string + ";key=value;";
-  result_type_hash = rmw_dds_common::parse_type_hash_from_user_data(
-    reinterpret_cast<uint8_t *>(good_data.data()), good_data.size());
+  ret = rmw_dds_common::parse_type_hash_from_user_data(
+    reinterpret_cast<uint8_t *>(good_data.data()), good_data.size(), result_type_hash);
+  EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_EQ(0, memcmp(&result_type_hash, &input_type_hash, sizeof(rosidl_type_hash_t)));
 }
 
 TEST(test_qos, test_encode_type_hash_for_user_data_qos)
 {
   rosidl_type_hash_t test_hash = rosidl_get_zero_initialized_type_hash();
-  EXPECT_EQ(rmw_dds_common::encode_type_hash_for_user_data_qos(test_hash), "");
+  std::string hash_string;
+  rmw_ret_t ret = rmw_dds_common::encode_type_hash_for_user_data_qos(test_hash, hash_string);
+  EXPECT_EQ(ret, RMW_RET_OK);
+  EXPECT_EQ(hash_string, "");
 
   test_hash.version = 1;
   for (uint8_t i = 0; i < ROSIDL_TYPE_HASH_SIZE; i++) {
     test_hash.value[i] = i;
   }
-  std::string result = rmw_dds_common::encode_type_hash_for_user_data_qos(test_hash);
+  hash_string.clear();
+  ret = rmw_dds_common::encode_type_hash_for_user_data_qos(test_hash, hash_string);
+  EXPECT_EQ(ret, RMW_RET_OK);
   EXPECT_EQ(
-    result,
+    hash_string,
     "typehash=RIHS01_000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f;");
 }


### PR DESCRIPTION
Part of ros2/ros2#1159
Depends on ros2/rosidl#722
Depends on ros2/rmw#348

Updates the `GraphCache`'s `EntityInfo` struct with a new field `topic_type_hash` that can be filled out during discovery by implementations, which is passed through to `rmw_topic_endpoint_info`.

Adds utility functions `parse_type_hash_from_user_data_qos` and `encode_type_hash_for_user_data_qos` for using this value as a `USER_DATA` QoS value during discovery.