### PR TITLE
make a new private mutex and add updating graph methods

### DIFF
--- a/rmw_dds_common/CMakeLists.txt
+++ b/rmw_dds_common/CMakeLists.txt
@@ -32,6 +32,7 @@ rosidl_generate_interfaces(
 )
 
 add_library(${PROJECT_NAME}_library
+  src/context.cpp
   src/gid_utils.cpp
   src/graph_cache.cpp
   src/qos.cpp

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -50,7 +50,8 @@ struct Context
   /// Guard condition that should be triggered when the graph changes.
   rmw_guard_condition_t * graph_guard_condition;
 
-  using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
+  using publish_callback_t =
+    std::function<rmw_ret_t(const rmw_publisher_t * pub, const void * msg)>;
   /// Publish a graph message when updating or destroying graph cache.
   publish_callback_t publish_callback;
 

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -49,6 +49,56 @@ struct Context
   rmw_guard_condition_t * listener_thread_gc;
   /// Guard condition that should be triggered when the graph changes.
   rmw_guard_condition_t * graph_guard_condition;
+
+  using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
+
+  rmw_ret_t update_node_graph(
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t destroy_node_graph(
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t update_subscriber_graph(
+    rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t destroy_subscriber_graph(
+    rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t update_publisher_graph(
+    rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t destroy_publisher_graph(
+    rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t update_client_graph(
+    rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t destroy_client_graph(
+    rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t update_service_graph(
+    rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+  rmw_ret_t destroy_service_graph(
+    rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+    const std::string& name, const std::string& namespace_,
+    publish_callback_t publish_callback);
+
+private:
+  // after all rmw are fixed, rename it with `node_update_mutex` and remove the original `node_update_mutex` above
+  std::mutex node_update_mutex_new;
 };
 
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -16,7 +16,9 @@
 #define RMW_DDS_COMMON__CONTEXT_HPP_
 
 #include <atomic>
+#include <functional>
 #include <mutex>
+#include <string>
 #include <thread>
 
 #include "rmw/types.h"
@@ -53,51 +55,52 @@ struct Context
   using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
 
   rmw_ret_t update_node_graph(
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t destroy_node_graph(
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t update_subscriber_graph(
-    rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+    rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t destroy_subscriber_graph(
-    rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+    rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t update_publisher_graph(
-    rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+    rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t destroy_publisher_graph(
-    rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+    rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t update_client_graph(
     rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t destroy_client_graph(
     rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t update_service_graph(
     rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   rmw_ret_t destroy_service_graph(
     rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
-    const std::string& name, const std::string& namespace_,
+    const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
 private:
-  // after all rmw are fixed, rename it with `node_update_mutex` and remove the original `node_update_mutex` above
+  /// After all rmw are fixed, rename it with `node_update_mutex` and
+  /// remove the original `node_update_mutex` above
   std::mutex node_update_mutex_new;
 };
 

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -54,46 +54,66 @@ struct Context
 
   using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
 
-  rmw_ret_t update_node_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  update_node_graph(
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t destroy_node_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  destroy_node_graph(
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t update_subscriber_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  update_subscriber_graph(
     rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t destroy_subscriber_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  destroy_subscriber_graph(
     rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t update_publisher_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  update_publisher_graph(
     rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t destroy_publisher_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  destroy_publisher_graph(
     rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t update_client_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  update_client_graph(
     rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t destroy_client_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  destroy_client_graph(
     rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t update_service_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  update_service_graph(
     rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
-  rmw_ret_t destroy_service_graph(
+  RMW_DDS_COMMON_PUBLIC
+  rmw_ret_t
+  destroy_service_graph(
     rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -54,42 +54,104 @@ struct Context
 
   using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
 
+  /// Update graph for creating a node.
+  /**
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_node_graph(
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for destroying a node.
+  /**
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_node_graph(
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for creating a subscription.
+  /**
+   * \param subscription_gid subscription gid.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_subscriber_graph(
     rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for destroying a subscription.
+  /**
+   * \param subscription_gid subscription gid.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_subscriber_graph(
     rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for creating a publisher.
+  /**
+   * \param publisher_gid publisher gid.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_publisher_graph(
     rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for destroying a publisher.
+  /**
+   * \param publisher_gid publisher gid.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_publisher_graph(
     rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for creating a client.
+  /**
+   * \param request_publisher_gid request publisher gid of the client.
+   * \param response_subscriber_gid response subscriber gid of the client.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_client_graph(
@@ -97,6 +159,16 @@ struct Context
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for destroying a client.
+  /**
+   * \param request_publisher_gid request publisher gid of the client.
+   * \param response_subscriber_gid response subscriber gid of the client.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_client_graph(
@@ -104,6 +176,16 @@ struct Context
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for creating a service.
+  /**
+   * \param request_subscriber_gid request subscriber gid of the client.
+   * \param response_publisher_gid response publisher gid of the client.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_service_graph(
@@ -111,6 +193,16 @@ struct Context
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
+  /// Update graph for destroying a service.
+  /**
+   * \param request_subscriber_gid request subscriber gid of the client.
+   * \param response_publisher_gid response publisher gid of the client.
+   * \param name node name.
+   * \param namespace_ node namespace.
+   * \param publish_callback a publish message callback.
+   * \return `RMW_RET_OK` if successful, or
+   * \return `RMW_RET_ERROR` an unexpected error occurs.
+   */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_service_graph(
@@ -119,7 +211,8 @@ struct Context
     publish_callback_t publish_callback);
 
 private:
-  /// After all rmw are fixed, rename it with `node_update_mutex` and
+  /// Mutex that should be locked when updating graph cache and publishing a graph message.
+  /// Todo: After all rmw are fixed, rename it with `node_update_mutex` and
   /// remove the original `node_update_mutex` above
   std::mutex node_update_mutex_new;
 };

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -55,7 +55,7 @@ struct Context
   /// Publish a graph message when updating or destroying graph cache.
   publish_callback_t publish_callback;
 
-  /// Update graph for creating a node.
+  /// Add graph for creating a node.
   /**
    * \param name node name.
    * \param namespace_ node namespace.
@@ -64,10 +64,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  update_node_graph(
+  add_node_graph(
     const std::string & name, const std::string & namespace_);
 
-  /// Update graph for destroying a node.
+  /// Remove graph for destroying a node.
   /**
    * \param name node name.
    * \param namespace_ node namespace.
@@ -76,10 +76,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  destroy_node_graph(
+  remove_node_graph(
     const std::string & name, const std::string & namespace_);
 
-  /// Update graph for creating a subscription.
+  /// Add graph for creating a subscription.
   /**
    * \param subscription_gid subscription gid.
    * \param name node name.
@@ -89,10 +89,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  update_subscriber_graph(
+  add_subscriber_graph(
     const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_);
 
-  /// Update graph for destroying a subscription.
+  /// Remove graph for destroying a subscription.
   /**
    * \param subscription_gid subscription gid.
    * \param name node name.
@@ -102,10 +102,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  destroy_subscriber_graph(
+  remove_subscriber_graph(
     const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_);
 
-  /// Update graph for creating a publisher.
+  /// Add graph for creating a publisher.
   /**
    * \param publisher_gid publisher gid.
    * \param name node name.
@@ -115,10 +115,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  update_publisher_graph(
+  add_publisher_graph(
     const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_);
 
-  /// Update graph for destroying a publisher.
+  /// Remove graph for destroying a publisher.
   /**
    * \param publisher_gid publisher gid.
    * \param name node name.
@@ -128,10 +128,10 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  destroy_publisher_graph(
+  remove_publisher_graph(
     const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_);
 
-  /// Update graph for creating a client.
+  /// Add graph for creating a client.
   /**
    * \param request_publisher_gid request publisher gid of the client.
    * \param response_subscriber_gid response subscriber gid of the client.
@@ -142,11 +142,11 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  update_client_graph(
+  add_client_graph(
     const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
     const std::string & name, const std::string & namespace_);
 
-  /// Update graph for destroying a client.
+  /// Remove graph for destroying a client.
   /**
    * \param request_publisher_gid request publisher gid of the client.
    * \param response_subscriber_gid response subscriber gid of the client.
@@ -157,11 +157,11 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  destroy_client_graph(
+  remove_client_graph(
     const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
     const std::string & name, const std::string & namespace_);
 
-  /// Update graph for creating a service.
+  /// Add graph for creating a service.
   /**
    * \param request_subscriber_gid request subscriber gid of the client.
    * \param response_publisher_gid response publisher gid of the client.
@@ -172,11 +172,11 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  update_service_graph(
+  add_service_graph(
     const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
     const std::string & name, const std::string & namespace_);
 
-  /// Update graph for destroying a service.
+  /// Remove graph for destroying a service.
   /**
    * \param request_subscriber_gid request subscriber gid of the client.
    * \param response_publisher_gid response publisher gid of the client.
@@ -187,12 +187,14 @@ struct Context
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
-  destroy_service_graph(
+  remove_service_graph(
     const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
     const std::string & name, const std::string & namespace_);
 
 private:
   /// Mutex that should be locked when updating graph cache and publishing a graph message.
+  /// Though graph_cache methods are thread safe, both cache update and publishing have to also
+  /// be atomic.
   std::mutex node_update_mutex;
 };
 

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -41,8 +41,6 @@ struct Context
   rmw_subscription_t * sub;
   /// Cached graph from discovery data.
   GraphCache graph_cache;
-  /// Mutex that should be locked when updating graph cache and publishing a graph message.
-  std::mutex node_update_mutex;
   /// Thread to listen to discovery data.
   std::thread listener_thread;
   /// Indicates if the listener thread is running.
@@ -94,7 +92,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_subscriber_graph(
-    rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   /// Update graph for destroying a subscription.
@@ -109,7 +107,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_subscriber_graph(
-    rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   /// Update graph for creating a publisher.
@@ -124,7 +122,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_publisher_graph(
-    rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   /// Update graph for destroying a publisher.
@@ -139,7 +137,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_publisher_graph(
-    rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
   /// Update graph for creating a client.
@@ -155,7 +153,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_client_graph(
-    rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+    const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
@@ -172,7 +170,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_client_graph(
-    rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+    const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
@@ -189,7 +187,7 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_service_graph(
-    rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+    const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
@@ -206,15 +204,13 @@ struct Context
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_service_graph(
-    rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+    const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
     const std::string & name, const std::string & namespace_,
     publish_callback_t publish_callback);
 
 private:
   /// Mutex that should be locked when updating graph cache and publishing a graph message.
-  /// Todo: After all rmw are fixed, rename it with `node_update_mutex` and
-  /// remove the original `node_update_mutex` above
-  std::mutex node_update_mutex_new;
+  std::mutex node_update_mutex;
 };
 
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/include/rmw_dds_common/context.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/context.hpp
@@ -51,94 +51,84 @@ struct Context
   rmw_guard_condition_t * graph_guard_condition;
 
   using publish_callback_t = std::function<rmw_ret_t(rmw_publisher_t * pub, void * msg)>;
+  /// Publish a graph message when updating or destroying graph cache.
+  publish_callback_t publish_callback;
 
   /// Update graph for creating a node.
   /**
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_node_graph(
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
   /// Update graph for destroying a node.
   /**
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_node_graph(
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
   /// Update graph for creating a subscription.
   /**
    * \param subscription_gid subscription gid.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_subscriber_graph(
-    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_);
 
   /// Update graph for destroying a subscription.
   /**
    * \param subscription_gid subscription gid.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_subscriber_graph(
-    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_);
 
   /// Update graph for creating a publisher.
   /**
    * \param publisher_gid publisher gid.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   update_publisher_graph(
-    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_);
 
   /// Update graph for destroying a publisher.
   /**
    * \param publisher_gid publisher gid.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
   RMW_DDS_COMMON_PUBLIC
   rmw_ret_t
   destroy_publisher_graph(
-    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_);
 
   /// Update graph for creating a client.
   /**
@@ -146,7 +136,6 @@ struct Context
    * \param response_subscriber_gid response subscriber gid of the client.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
@@ -154,8 +143,7 @@ struct Context
   rmw_ret_t
   update_client_graph(
     const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
   /// Update graph for destroying a client.
   /**
@@ -163,7 +151,6 @@ struct Context
    * \param response_subscriber_gid response subscriber gid of the client.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
@@ -171,8 +158,7 @@ struct Context
   rmw_ret_t
   destroy_client_graph(
     const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
   /// Update graph for creating a service.
   /**
@@ -180,7 +166,6 @@ struct Context
    * \param response_publisher_gid response publisher gid of the client.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
@@ -188,8 +173,7 @@ struct Context
   rmw_ret_t
   update_service_graph(
     const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
   /// Update graph for destroying a service.
   /**
@@ -197,7 +181,6 @@ struct Context
    * \param response_publisher_gid response publisher gid of the client.
    * \param name node name.
    * \param namespace_ node namespace.
-   * \param publish_callback a publish message callback.
    * \return `RMW_RET_OK` if successful, or
    * \return `RMW_RET_ERROR` an unexpected error occurs.
    */
@@ -205,8 +188,7 @@ struct Context
   rmw_ret_t
   destroy_service_graph(
     const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
-    const std::string & name, const std::string & namespace_,
-    publish_callback_t publish_callback);
+    const std::string & name, const std::string & namespace_);
 
 private:
   /// Mutex that should be locked when updating graph cache and publishing a graph message.

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -17,8 +17,9 @@
 #include <mutex>
 #include <string>
 
-#include <rmw/types.h>
-#include <rmw_dds_common/msg/participant_entities_info.hpp>
+#include "rmw/types.h"
+
+#include "rmw_dds_common/msg/participant_entities_info.hpp"
 
 namespace rmw_dds_common
 {

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -18,8 +18,7 @@ namespace rmw_dds_common
 {
 
 rmw_ret_t Context::update_node_graph(
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -34,8 +33,7 @@ rmw_ret_t Context::update_node_graph(
 }
 
 rmw_ret_t Context::destroy_node_graph(
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -49,8 +47,7 @@ rmw_ret_t Context::destroy_node_graph(
 }
 
 rmw_ret_t Context::update_subscriber_graph(
-  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -67,8 +64,7 @@ rmw_ret_t Context::update_subscriber_graph(
 }
 
 rmw_ret_t Context::destroy_subscriber_graph(
-  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -83,8 +79,7 @@ rmw_ret_t Context::destroy_subscriber_graph(
 }
 
 rmw_ret_t Context::update_publisher_graph(
-  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -101,8 +96,7 @@ rmw_ret_t Context::update_publisher_graph(
 }
 
 rmw_ret_t Context::destroy_publisher_graph(
-  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
@@ -118,8 +112,7 @@ rmw_ret_t Context::destroy_publisher_graph(
 
 rmw_ret_t Context::update_client_graph(
   const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.associate_writer(
@@ -142,8 +135,7 @@ rmw_ret_t Context::update_client_graph(
 
 rmw_ret_t Context::destroy_client_graph(
   const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.dissociate_writer(
@@ -162,8 +154,7 @@ rmw_ret_t Context::destroy_client_graph(
 
 rmw_ret_t Context::update_service_graph(
   const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.associate_reader(
@@ -186,8 +177,7 @@ rmw_ret_t Context::update_service_graph(
 
 rmw_ret_t Context::destroy_service_graph(
   const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
-  const std::string & name, const std::string & namespace_,
-  publish_callback_t publish_callback)
+  const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.dissociate_reader(

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -18,9 +18,9 @@ namespace rmw_dds_common
 {
 
 rmw_ret_t Context::update_node_graph(
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.add_node(gid, name, namespace_);
@@ -29,9 +29,9 @@ rmw_ret_t Context::update_node_graph(
 }
 
 rmw_ret_t Context::destroy_node_graph(
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.remove_node(gid, name, namespace_);
@@ -40,9 +40,9 @@ rmw_ret_t Context::destroy_node_graph(
 }
 
 rmw_ret_t Context::update_subscriber_graph(
-  rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.associate_reader(
@@ -60,9 +60,9 @@ rmw_ret_t Context::update_subscriber_graph(
 }
 
 rmw_ret_t Context::destroy_subscriber_graph(
-  rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.dissociate_reader(
@@ -72,9 +72,9 @@ rmw_ret_t Context::destroy_subscriber_graph(
 }
 
 rmw_ret_t Context::update_publisher_graph(
-  rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.associate_writer(
@@ -92,9 +92,9 @@ rmw_ret_t Context::update_publisher_graph(
 }
 
 rmw_ret_t Context::destroy_publisher_graph(
-  rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.dissociate_writer(
@@ -105,9 +105,9 @@ rmw_ret_t Context::destroy_publisher_graph(
 
 rmw_ret_t Context::update_client_graph(
   rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   graph_cache.associate_writer(
     request_publisher_gid, gid, name, namespace_);
@@ -131,9 +131,9 @@ rmw_ret_t Context::update_client_graph(
 
 rmw_ret_t Context::destroy_client_graph(
   rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   graph_cache.dissociate_writer(
     request_publisher_gid, gid, name, namespace_);
@@ -147,9 +147,9 @@ rmw_ret_t Context::destroy_client_graph(
 
 rmw_ret_t Context::update_service_graph(
   rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   graph_cache.associate_reader(
     request_subscriber_gid, gid, name, namespace_);
@@ -173,9 +173,9 @@ rmw_ret_t Context::update_service_graph(
 
 rmw_ret_t Context::destroy_service_graph(
   rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
-  const std::string& name, const std::string& namespace_,
-  publish_callback_t publish_callback) {
-
+  const std::string & name, const std::string & namespace_,
+  publish_callback_t publish_callback)
+{
   std::lock_guard<std::mutex> guard(node_update_mutex_new);
   graph_cache.dissociate_reader(
     request_subscriber_gid, gid, name, namespace_);
@@ -187,4 +187,4 @@ rmw_ret_t Context::destroy_service_graph(
   return publish_callback(pub, static_cast<void *>(&msg));
 }
 
-}  // rmw_dds_common
+}  // namespace rmw_dds_common

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -25,7 +25,12 @@ rmw_ret_t Context::update_node_graph(
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.add_node(gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    graph_cache.remove_node(gid, name, namespace_);
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t Context::destroy_node_graph(
@@ -36,7 +41,11 @@ rmw_ret_t Context::destroy_node_graph(
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.remove_node(gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t Context::update_subscriber_graph(
@@ -48,12 +57,10 @@ rmw_ret_t Context::update_subscriber_graph(
     graph_cache.associate_reader(
     subscription_gid, gid, name, namespace_);
 
-  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
     static_cast<void>(graph_cache.dissociate_reader(
       subscription_gid, gid, name, namespace_));
-    return rmw_ret;
+    return RMW_RET_ERROR;
   }
 
   return RMW_RET_OK;
@@ -68,7 +75,11 @@ rmw_ret_t Context::destroy_subscriber_graph(
     graph_cache.dissociate_reader(
     subscription_gid, gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t Context::update_publisher_graph(
@@ -80,12 +91,10 @@ rmw_ret_t Context::update_publisher_graph(
     graph_cache.associate_writer(
     publisher_gid, gid, name, namespace_);
 
-  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
     static_cast<void>(graph_cache.dissociate_writer(
       publisher_gid, gid, name, namespace_));
-    return rmw_ret;
+    return RMW_RET_ERROR;
   }
 
   return RMW_RET_OK;
@@ -100,7 +109,11 @@ rmw_ret_t Context::destroy_publisher_graph(
     graph_cache.dissociate_writer(
     publisher_gid, gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t Context::update_client_graph(
@@ -116,14 +129,12 @@ rmw_ret_t Context::update_client_graph(
     graph_cache.associate_reader(
     response_subscriber_gid, gid, name, namespace_);
 
-  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
     static_cast<void>(graph_cache.dissociate_reader(
       response_subscriber_gid, gid, name, namespace_));
     static_cast<void>(graph_cache.dissociate_writer(
       request_publisher_gid, gid, name, namespace_));
-    return rmw_ret;
+    return RMW_RET_ERROR;
   }
 
   return RMW_RET_OK;
@@ -142,7 +153,11 @@ rmw_ret_t Context::destroy_client_graph(
     graph_cache.dissociate_reader(
     response_subscriber_gid, gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 rmw_ret_t Context::update_service_graph(
@@ -158,14 +173,12 @@ rmw_ret_t Context::update_service_graph(
     graph_cache.associate_writer(
     response_publisher_gid, gid, name, namespace_);
 
-  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
-
-  if (RMW_RET_OK != rmw_ret) {
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
     static_cast<void>(graph_cache.dissociate_writer(
       response_publisher_gid, gid, name, namespace_));
     static_cast<void>(graph_cache.dissociate_reader(
       request_subscriber_gid, gid, name, namespace_));
-    return rmw_ret;
+    return RMW_RET_ERROR;
   }
 
   return RMW_RET_OK;
@@ -184,7 +197,11 @@ rmw_ret_t Context::destroy_service_graph(
     graph_cache.dissociate_writer(
     response_publisher_gid, gid, name, namespace_);
 
-  return publish_callback(pub, static_cast<void *>(&msg));
+  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
 }
 
 }  // namespace rmw_dds_common

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -17,6 +17,19 @@
 namespace rmw_dds_common
 {
 
+static bool publish_(
+  const rmw_publisher_t * pub,
+  const Context::publish_callback_t & publish_callback,
+  const rmw_dds_common::msg::ParticipantEntitiesInfo & msg)
+{
+  if (nullptr == pub || nullptr == publish_callback ||
+    RMW_RET_OK != publish_callback(pub, static_cast<const void *>(&msg)))
+  {
+    return false;
+  }
+  return true;
+}
+
 rmw_ret_t Context::update_node_graph(
   const std::string & name, const std::string & namespace_)
 {
@@ -24,7 +37,7 @@ rmw_ret_t Context::update_node_graph(
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.add_node(gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     graph_cache.remove_node(gid, name, namespace_);
     return RMW_RET_ERROR;
   }
@@ -39,7 +52,7 @@ rmw_ret_t Context::destroy_node_graph(
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.remove_node(gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     return RMW_RET_ERROR;
   }
 
@@ -54,7 +67,7 @@ rmw_ret_t Context::update_subscriber_graph(
     graph_cache.associate_reader(
     subscription_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     static_cast<void>(graph_cache.dissociate_reader(
       subscription_gid, gid, name, namespace_));
     return RMW_RET_ERROR;
@@ -71,7 +84,7 @@ rmw_ret_t Context::destroy_subscriber_graph(
     graph_cache.dissociate_reader(
     subscription_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     return RMW_RET_ERROR;
   }
 
@@ -86,7 +99,7 @@ rmw_ret_t Context::update_publisher_graph(
     graph_cache.associate_writer(
     publisher_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     static_cast<void>(graph_cache.dissociate_writer(
       publisher_gid, gid, name, namespace_));
     return RMW_RET_ERROR;
@@ -103,7 +116,7 @@ rmw_ret_t Context::destroy_publisher_graph(
     graph_cache.dissociate_writer(
     publisher_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     return RMW_RET_ERROR;
   }
 
@@ -122,7 +135,7 @@ rmw_ret_t Context::update_client_graph(
     graph_cache.associate_reader(
     response_subscriber_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     static_cast<void>(graph_cache.dissociate_reader(
       response_subscriber_gid, gid, name, namespace_));
     static_cast<void>(graph_cache.dissociate_writer(
@@ -145,7 +158,7 @@ rmw_ret_t Context::destroy_client_graph(
     graph_cache.dissociate_reader(
     response_subscriber_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     return RMW_RET_ERROR;
   }
 
@@ -164,7 +177,7 @@ rmw_ret_t Context::update_service_graph(
     graph_cache.associate_writer(
     response_publisher_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     static_cast<void>(graph_cache.dissociate_writer(
       response_publisher_gid, gid, name, namespace_));
     static_cast<void>(graph_cache.dissociate_reader(
@@ -187,7 +200,7 @@ rmw_ret_t Context::destroy_service_graph(
     graph_cache.dissociate_writer(
     response_publisher_gid, gid, name, namespace_);
 
-  if (nullptr == pub || RMW_RET_OK != publish_callback(pub, static_cast<void *>(&msg))) {
+  if (!publish_(pub, publish_callback, msg)) {
     return RMW_RET_ERROR;
   }
 

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -21,7 +21,7 @@ rmw_ret_t Context::update_node_graph(
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.add_node(gid, name, namespace_);
 
@@ -37,7 +37,7 @@ rmw_ret_t Context::destroy_node_graph(
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.remove_node(gid, name, namespace_);
 
@@ -49,10 +49,10 @@ rmw_ret_t Context::destroy_node_graph(
 }
 
 rmw_ret_t Context::update_subscriber_graph(
-  rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.associate_reader(
     subscription_gid, gid, name, namespace_);
@@ -67,10 +67,10 @@ rmw_ret_t Context::update_subscriber_graph(
 }
 
 rmw_ret_t Context::destroy_subscriber_graph(
-  rmw_gid_t subscription_gid, const std::string & name, const std::string & namespace_,
+  const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.dissociate_reader(
     subscription_gid, gid, name, namespace_);
@@ -83,10 +83,10 @@ rmw_ret_t Context::destroy_subscriber_graph(
 }
 
 rmw_ret_t Context::update_publisher_graph(
-  rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.associate_writer(
     publisher_gid, gid, name, namespace_);
@@ -101,10 +101,10 @@ rmw_ret_t Context::update_publisher_graph(
 }
 
 rmw_ret_t Context::destroy_publisher_graph(
-  rmw_gid_t publisher_gid, const std::string & name, const std::string & namespace_,
+  const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.dissociate_writer(
     publisher_gid, gid, name, namespace_);
@@ -117,11 +117,11 @@ rmw_ret_t Context::destroy_publisher_graph(
 }
 
 rmw_ret_t Context::update_client_graph(
-  rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+  const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.associate_writer(
     request_publisher_gid, gid, name, namespace_);
 
@@ -141,11 +141,11 @@ rmw_ret_t Context::update_client_graph(
 }
 
 rmw_ret_t Context::destroy_client_graph(
-  rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+  const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.dissociate_writer(
     request_publisher_gid, gid, name, namespace_);
 
@@ -161,11 +161,11 @@ rmw_ret_t Context::destroy_client_graph(
 }
 
 rmw_ret_t Context::update_service_graph(
-  rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+  const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.associate_reader(
     request_subscriber_gid, gid, name, namespace_);
 
@@ -185,11 +185,11 @@ rmw_ret_t Context::update_service_graph(
 }
 
 rmw_ret_t Context::destroy_service_graph(
-  rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+  const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
   const std::string & name, const std::string & namespace_,
   publish_callback_t publish_callback)
 {
-  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  std::lock_guard<std::mutex> guard(node_update_mutex);
   graph_cache.dissociate_reader(
     request_subscriber_gid, gid, name, namespace_);
 

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Open Source Robotics Foundation, Inc.
+// Copyright 2023 Sony Group Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,14 +37,9 @@ static bool call_publish_callback(
   return true;
 }
 
-rmw_ret_t Context::update_node_graph(
+rmw_ret_t Context::add_node_graph(
   const std::string & name, const std::string & namespace_)
 {
-  // Though graph_cache methods are thread safe, both cache update and publishing have to also
-  // be atomic.
-  // If not, the following race condition is possible:
-  // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
-  // In that case, the last message published is not accurate.
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.add_node(gid, name, namespace_);
@@ -57,14 +52,9 @@ rmw_ret_t Context::update_node_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::destroy_node_graph(
+rmw_ret_t Context::remove_node_graph(
   const std::string & name, const std::string & namespace_)
 {
-  // Though graph_cache methods are thread safe, both cache update and publishing have to also
-  // be atomic.
-  // If not, the following race condition is possible:
-  // node1-update-get-message / node2-update-get-message / node2-publish / node1-publish
-  // In that case, the last message published is not accurate.
   std::lock_guard<std::mutex> guard(node_update_mutex);
   rmw_dds_common::msg::ParticipantEntitiesInfo msg =
     graph_cache.remove_node(gid, name, namespace_);
@@ -76,7 +66,7 @@ rmw_ret_t Context::destroy_node_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::update_subscriber_graph(
+rmw_ret_t Context::add_subscriber_graph(
   const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
@@ -93,7 +83,7 @@ rmw_ret_t Context::update_subscriber_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::destroy_subscriber_graph(
+rmw_ret_t Context::remove_subscriber_graph(
   const rmw_gid_t & subscription_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
@@ -108,7 +98,7 @@ rmw_ret_t Context::destroy_subscriber_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::update_publisher_graph(
+rmw_ret_t Context::add_publisher_graph(
   const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
@@ -125,7 +115,7 @@ rmw_ret_t Context::update_publisher_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::destroy_publisher_graph(
+rmw_ret_t Context::remove_publisher_graph(
   const rmw_gid_t & publisher_gid, const std::string & name, const std::string & namespace_)
 {
   std::lock_guard<std::mutex> guard(node_update_mutex);
@@ -140,7 +130,7 @@ rmw_ret_t Context::destroy_publisher_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::update_client_graph(
+rmw_ret_t Context::add_client_graph(
   const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
   const std::string & name, const std::string & namespace_)
 {
@@ -163,7 +153,7 @@ rmw_ret_t Context::update_client_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::destroy_client_graph(
+rmw_ret_t Context::remove_client_graph(
   const rmw_gid_t & request_publisher_gid, const rmw_gid_t & response_subscriber_gid,
   const std::string & name, const std::string & namespace_)
 {
@@ -182,7 +172,7 @@ rmw_ret_t Context::destroy_client_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::update_service_graph(
+rmw_ret_t Context::add_service_graph(
   const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
   const std::string & name, const std::string & namespace_)
 {
@@ -205,7 +195,7 @@ rmw_ret_t Context::update_service_graph(
   return RMW_RET_OK;
 }
 
-rmw_ret_t Context::destroy_service_graph(
+rmw_ret_t Context::remove_service_graph(
   const rmw_gid_t & request_subscriber_gid, const rmw_gid_t & response_publisher_gid,
   const std::string & name, const std::string & namespace_)
 {

--- a/rmw_dds_common/src/context.cpp
+++ b/rmw_dds_common/src/context.cpp
@@ -1,0 +1,190 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_dds_common/context.hpp"
+
+namespace rmw_dds_common
+{
+
+rmw_ret_t Context::update_node_graph(
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.add_node(gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+rmw_ret_t Context::destroy_node_graph(
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.remove_node(gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+rmw_ret_t Context::update_subscriber_graph(
+  rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.associate_reader(
+    subscription_gid, gid, name, namespace_);
+
+  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
+
+  if (RMW_RET_OK != rmw_ret) {
+    static_cast<void>(graph_cache.dissociate_reader(
+      subscription_gid, gid, name, namespace_));
+    return rmw_ret;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t Context::destroy_subscriber_graph(
+  rmw_gid_t subscription_gid, const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.dissociate_reader(
+    subscription_gid, gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+rmw_ret_t Context::update_publisher_graph(
+  rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.associate_writer(
+    publisher_gid, gid, name, namespace_);
+
+  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
+
+  if (RMW_RET_OK != rmw_ret) {
+    static_cast<void>(graph_cache.dissociate_writer(
+      publisher_gid, gid, name, namespace_));
+    return rmw_ret;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t Context::destroy_publisher_graph(
+  rmw_gid_t publisher_gid, const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.dissociate_writer(
+    publisher_gid, gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+rmw_ret_t Context::update_client_graph(
+  rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  graph_cache.associate_writer(
+    request_publisher_gid, gid, name, namespace_);
+
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.associate_reader(
+    response_subscriber_gid, gid, name, namespace_);
+
+  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
+
+  if (RMW_RET_OK != rmw_ret) {
+    static_cast<void>(graph_cache.dissociate_reader(
+      response_subscriber_gid, gid, name, namespace_));
+    static_cast<void>(graph_cache.dissociate_writer(
+      request_publisher_gid, gid, name, namespace_));
+    return rmw_ret;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t Context::destroy_client_graph(
+  rmw_gid_t request_publisher_gid, rmw_gid_t response_subscriber_gid,
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  graph_cache.dissociate_writer(
+    request_publisher_gid, gid, name, namespace_);
+
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.dissociate_reader(
+    response_subscriber_gid, gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+rmw_ret_t Context::update_service_graph(
+  rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  graph_cache.associate_reader(
+    request_subscriber_gid, gid, name, namespace_);
+
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.associate_writer(
+    response_publisher_gid, gid, name, namespace_);
+
+  rmw_ret_t rmw_ret = publish_callback(pub, static_cast<void *>(&msg));
+
+  if (RMW_RET_OK != rmw_ret) {
+    static_cast<void>(graph_cache.dissociate_writer(
+      response_publisher_gid, gid, name, namespace_));
+    static_cast<void>(graph_cache.dissociate_reader(
+      request_subscriber_gid, gid, name, namespace_));
+    return rmw_ret;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t Context::destroy_service_graph(
+  rmw_gid_t request_subscriber_gid, rmw_gid_t response_publisher_gid,
+  const std::string& name, const std::string& namespace_,
+  publish_callback_t publish_callback) {
+
+  std::lock_guard<std::mutex> guard(node_update_mutex_new);
+  graph_cache.dissociate_reader(
+    request_subscriber_gid, gid, name, namespace_);
+
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg =
+    graph_cache.dissociate_writer(
+    response_publisher_gid, gid, name, namespace_);
+
+  return publish_callback(pub, static_cast<void *>(&msg));
+}
+
+}  // rmw_dds_common


### PR DESCRIPTION
Its intent is to avoid using mutex directly outside, and decrease the replicated code about updating graph in RMWs.