### PR TITLE
Quicker handling of topics with 0-size user_data.

### DIFF
--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -675,6 +675,9 @@ parse_type_hash_from_user_data(
   size_t user_data_size,
   rosidl_type_hash_t & type_hash_out)
 {
+  if (user_data_size == 0) {
+    return RMW_RET_OK;
+  }
   RMW_CHECK_ARGUMENT_FOR_NULL(user_data, RMW_RET_INVALID_ARGUMENT);
   std::vector<uint8_t> udvec(user_data, user_data + user_data_size);
   auto key_value = rmw::impl::cpp::parse_key_value(udvec);

--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -676,6 +676,7 @@ parse_type_hash_from_user_data(
   rosidl_type_hash_t & type_hash_out)
 {
   if (user_data_size == 0) {
+    type_hash_out = rosidl_get_zero_initialized_type_hash();
     return RMW_RET_OK;
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(user_data, RMW_RET_INVALID_ARGUMENT);


### PR DESCRIPTION
This change adds an early test to see: if there is no 'user_data' (size 0) to parse a type hash, then immediately return OK with a zero-init typehash struct.  This avoids executing the rest of the function which would return the same end result.

Topics without user_data can appear when ROS2 apps are run on networks that also carry non-ROS2 DDS traffic. 
ROS2 uses the user_data portion of the [Pub|Sub]BuiltinTopicData to carry a "typehash=xxx..." string, but non-ROS2 DDS apps are less likely to use this field, resulting in a 0-length buffer of user_data which is passed to parse_type_hash_from_user_data().  This change detects this condition early, and should have no effect on regular ROS2 topics that use the user_data field.

Tested against rmw connextdds, fastrtps_cpp, cyclonedds_cpp on Iron and Jazzy.  Code in Rolling is the same as in these versions.