### PR TITLE
Remove deprecated GraphCache methods without type hash

### DIFF
--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -99,21 +99,6 @@ public:
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
-  /// Add a data writer based on discovery.
-  /**
-   * See add_reader with rosidl_type_hash_t, whose other parameters match these.
-   */
-  RMW_DDS_COMMON_PUBLIC
-    RCUTILS_DEPRECATED_WITH_MSG(
-    "Migrate to using the version of this function taking a type hash.")
-  bool
-  add_writer(
-    const rmw_gid_t & writer_gid,
-    const std::string & topic_name,
-    const std::string & type_name,
-    const rmw_gid_t & participant_gid,
-    const rmw_qos_profile_t & qos);
-
   /// Add a data reader based on discovery.
   /**
    * \param reader_gid GUID of the The data reader.
@@ -132,21 +117,6 @@ public:
     const std::string & topic_name,
     const std::string & type_name,
     const rosidl_type_hash_t & type_hash,
-    const rmw_gid_t & participant_gid,
-    const rmw_qos_profile_t & qos);
-
-  /// Add a data reader based on discovery.
-  /**
-   * See add_reader with rosidl_type_hash_t, whose other parameters match these.
-   */
-  RMW_DDS_COMMON_PUBLIC
-    RCUTILS_DEPRECATED_WITH_MSG(
-    "Migrate to using the version of this function taking a type hash.")
-  bool
-  add_reader(
-    const rmw_gid_t & reader_gid,
-    const std::string & topic_name,
-    const std::string & type_name,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos);
 
@@ -169,22 +139,6 @@ public:
     const std::string & topic_name,
     const std::string & type_name,
     const rosidl_type_hash_t & type_hash,
-    const rmw_gid_t & participant_gid,
-    const rmw_qos_profile_t & qos,
-    bool is_reader);
-
-  /// Add a data reader or writer.
-  /**
-   * See add_entity with rosidl_type_hash_t, whose other parameters match these.
-   */
-  RMW_DDS_COMMON_PUBLIC
-    RCUTILS_DEPRECATED_WITH_MSG(
-    "Migrate to using the version of this function taking a type hash.")
-  bool
-  add_entity(
-    const rmw_gid_t & gid,
-    const std::string & topic_name,
-    const std::string & type_name,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
     bool is_reader);

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -81,23 +81,6 @@ GraphCache::add_writer(
 }
 
 bool
-GraphCache::add_writer(
-  const rmw_gid_t & gid,
-  const std::string & topic_name,
-  const std::string & type_name,
-  const rmw_gid_t & participant_gid,
-  const rmw_qos_profile_t & qos)
-{
-  return this->add_writer(
-    gid,
-    topic_name,
-    type_name,
-    rosidl_get_zero_initialized_type_hash(),
-    participant_gid,
-    qos);
-}
-
-bool
 GraphCache::add_reader(
   const rmw_gid_t & gid,
   const std::string & topic_name,
@@ -113,23 +96,6 @@ GraphCache::add_reader(
     std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
   GRAPH_CACHE_CALL_ON_CHANGE_CALLBACK_IF(this, pair.second);
   return pair.second;
-}
-
-bool
-GraphCache::add_reader(
-  const rmw_gid_t & gid,
-  const std::string & topic_name,
-  const std::string & type_name,
-  const rmw_gid_t & participant_gid,
-  const rmw_qos_profile_t & qos)
-{
-  return this->add_reader(
-    gid,
-    topic_name,
-    type_name,
-    rosidl_get_zero_initialized_type_hash(),
-    participant_gid,
-    qos);
 }
 
 bool
@@ -158,25 +124,6 @@ GraphCache::add_entity(
     type_hash,
     participant_gid,
     qos);
-}
-
-bool
-GraphCache::add_entity(
-  const rmw_gid_t & gid,
-  const std::string & topic_name,
-  const std::string & type_name,
-  const rmw_gid_t & participant_gid,
-  const rmw_qos_profile_t & qos,
-  bool is_reader)
-{
-  return this->add_entity(
-    gid,
-    topic_name,
-    type_name,
-    rosidl_get_zero_initialized_type_hash(),
-    participant_gid,
-    qos,
-    is_reader);
 }
 
 bool


### PR DESCRIPTION
## Description

They were deprecated in https://github.com/ros2/rmw_dds_common/pull/70 for Iron and safe to remove in Jazzy.

### Is this user-facing behavior change?

This is the tock part of the [tick-tock deprecation strategy](https://docs.ros.org/en/rolling/The-ROS2-Project/Contributing/Developer-Guide.html#deprecation-strategy).

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

There were concerns in #70 about breaking `rmw_gurumdds_cpp`. I quickly confirmed that it was updated: https://github.com/ros2/rmw_gurumdds/commit/56d7213abd8b0d23fa5f89e41c29a29fef58a3b7.