### PR TITLE
If no publishers discovered, make the best available QoS for subscrip…

### DIFF
--- a/rmw_dds_common/src/qos.cpp
+++ b/rmw_dds_common/src/qos.cpp
@@ -441,7 +441,8 @@ qos_profile_get_best_available_for_subscription(
   }
 
   if (RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE == subscription_profile->reliability) {
-    if (number_of_reliable == publishers_info->size) {
+    // avoid incorrectly selecting RELIABLE when no publishers are discovered
+    if (publishers_info->size > 0 && number_of_reliable == publishers_info->size) {
       subscription_profile->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
     } else {
       subscription_profile->reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
@@ -449,7 +450,8 @@ qos_profile_get_best_available_for_subscription(
   }
 
   if (RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE == subscription_profile->durability) {
-    if (number_of_transient_local == publishers_info->size) {
+    // avoid incorrectly selecting TRANSIENT_LOCAL when no publishers are discovered
+    if (publishers_info->size > 0 && number_of_transient_local == publishers_info->size) {
       subscription_profile->durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
     } else {
       subscription_profile->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
@@ -457,7 +459,8 @@ qos_profile_get_best_available_for_subscription(
   }
 
   if (RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE == subscription_profile->liveliness) {
-    if (number_of_manual_by_topic == publishers_info->size) {
+    // avoid incorrectly selecting MANUAL_BY_TOPIC when no publishers are discovered
+    if (publishers_info->size > 0 && number_of_manual_by_topic == publishers_info->size) {
       subscription_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC;
     } else {
       subscription_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;

--- a/rmw_dds_common/test/test_qos.cpp
+++ b/rmw_dds_common/test/test_qos.cpp
@@ -775,9 +775,9 @@ TEST(test_qos, test_qos_profile_get_best_available_for_subscription)
     rmw_ret_t ret = rmw_dds_common::qos_profile_get_best_available_for_subscription(
       &zeroed_publishers_info, &subscription_profile);
     EXPECT_EQ(ret, RMW_RET_OK);
-    EXPECT_EQ(subscription_profile.reliability, RMW_QOS_POLICY_RELIABILITY_RELIABLE);
-    EXPECT_EQ(subscription_profile.durability, RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL);
-    EXPECT_EQ(subscription_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC);
+    EXPECT_EQ(subscription_profile.reliability, RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+    EXPECT_EQ(subscription_profile.durability, RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    EXPECT_EQ(subscription_profile.liveliness, RMW_QOS_POLICY_LIVELINESS_AUTOMATIC);
     EXPECT_TRUE(
       rmw_time_equal(
         subscription_profile.liveliness_lease_duration,


### PR DESCRIPTION
…tion.

## Description

There is a possibility that the subscription has not yet discovered the corresponding publisher at the time of its creation.
In such cases, the current implementation causes those `if statements` to fall back to a restricted QoS configuration for the subscription.
However, this behavior seems incorrect for me. instead, it should fall back to selecting the best available QoS configuration that remains compatible with any endpoints that may join later.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Closes https://github.com/ros2/ros2/issues/1722

Replaces https://github.com/ros2/rclpy/pull/1561

### Is this user-facing behavior change?

No,

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No,

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

I confirmed that https://github.com/ros2/ros2/issues/1722 can be fixed with this PR.

<!--
If applicable, provide any additional context or details about the changes.
-->

> [!WARNING]
> We need to backport this to kilted and jazzy if accepted