### PR TITLE
Store rosidl buffer backend metadata in graph cache

### DIFF
--- a/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
+++ b/rmw_dds_common/include/rmw_dds_common/graph_cache.hpp
@@ -103,7 +103,8 @@ public:
     const rosidl_type_hash_t & type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
-    const rosidl_type_hash_t * service_type_hash = nullptr);
+    const rosidl_type_hash_t * service_type_hash = nullptr,
+    const std::unordered_map<std::string, std::string> & buffer_backend_metadata = {});
 
   /// Add a data reader based on discovery.
   /**
@@ -127,7 +128,8 @@ public:
     const rosidl_type_hash_t & type_hash,
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
-    const rosidl_type_hash_t * service_type_hash = nullptr);
+    const rosidl_type_hash_t * service_type_hash = nullptr,
+    const std::unordered_map<std::string, std::string> & buffer_backend_metadata = {});
 
   /// Add a data reader or writer.
   /**
@@ -153,7 +155,8 @@ public:
     const rmw_gid_t & participant_gid,
     const rmw_qos_profile_t & qos,
     bool is_reader,
-    const rosidl_type_hash_t * service_type_hash = nullptr);
+    const rosidl_type_hash_t * service_type_hash = nullptr,
+    const std::unordered_map<std::string, std::string> & buffer_backend_metadata = {});
 
   /// Remove a data writer.
   /**
@@ -611,6 +614,8 @@ struct EntityInfo
   rmw_gid_t participant_gid;
   /// Quality of service of the topic.
   rmw_qos_profile_t qos;
+  /// Buffer backend metadata advertised for this endpoint.
+  std::unordered_map<std::string, std::string> buffer_backend_metadata;
 
   /// Simple constructor.
   EntityInfo(
@@ -618,12 +623,14 @@ struct EntityInfo
     const std::string & topic_type,
     const rosidl_type_hash_t & topic_type_hash,
     const rmw_gid_t & participant_gid,
-    const rmw_qos_profile_t & qos)
+    const rmw_qos_profile_t & qos,
+    const std::unordered_map<std::string, std::string> & buffer_backend_metadata = {})
   : topic_name(topic_name),
     topic_type(topic_type),
     topic_type_hash(topic_type_hash),
     participant_gid(participant_gid),
-    qos(qos)
+    qos(qos),
+    buffer_backend_metadata(buffer_backend_metadata)
   {}
 };
 

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -31,6 +31,8 @@
 #include <vector>
 
 #include "rcutils/strdup.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types/string_map.h"
 
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
@@ -70,13 +72,15 @@ GraphCache::add_writer(
   const rosidl_type_hash_t & type_hash,
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos,
-  const rosidl_type_hash_t * service_type_hash)
+  const rosidl_type_hash_t * service_type_hash,
+  const std::unordered_map<std::string, std::string> & buffer_backend_metadata)
 {
   std::lock_guard<std::mutex> guard(mutex_);
   auto pair = data_writers_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(gid),
-    std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
+    std::forward_as_tuple(
+      topic_name, type_name, type_hash, participant_gid, qos, buffer_backend_metadata));
   if (service_type_hash) {
     data_services_.emplace(
       std::piecewise_construct,
@@ -95,13 +99,15 @@ GraphCache::add_reader(
   const rosidl_type_hash_t & type_hash,
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos,
-  const rosidl_type_hash_t * service_type_hash)
+  const rosidl_type_hash_t * service_type_hash,
+  const std::unordered_map<std::string, std::string> & buffer_backend_metadata)
 {
   std::lock_guard<std::mutex> guard(mutex_);
   auto pair = data_readers_.emplace(
     std::piecewise_construct,
     std::forward_as_tuple(gid),
-    std::forward_as_tuple(topic_name, type_name, type_hash, participant_gid, qos));
+    std::forward_as_tuple(
+      topic_name, type_name, type_hash, participant_gid, qos, buffer_backend_metadata));
   if (service_type_hash) {
     data_services_.emplace(
       std::piecewise_construct,
@@ -121,7 +127,8 @@ GraphCache::add_entity(
   const rmw_gid_t & participant_gid,
   const rmw_qos_profile_t & qos,
   bool is_reader,
-  const rosidl_type_hash_t * service_type_hash)
+  const rosidl_type_hash_t * service_type_hash,
+  const std::unordered_map<std::string, std::string> & buffer_backend_metadata)
 {
   if (is_reader) {
     return this->add_reader(
@@ -131,7 +138,8 @@ GraphCache::add_entity(
       type_hash,
       participant_gid,
       qos,
-      service_type_hash);
+      service_type_hash,
+      buffer_backend_metadata);
   }
   return this->add_writer(
     gid,
@@ -140,7 +148,8 @@ GraphCache::add_entity(
     type_hash,
     participant_gid,
     qos,
-    service_type_hash);
+    service_type_hash,
+    buffer_backend_metadata);
 }
 
 bool
@@ -621,6 +630,43 @@ __get_entities_info_by_topic(
       &entity_pair.second.qos);
     if (RMW_RET_OK != ret) {
       return ret;
+    }
+
+    if (!entity_pair.second.buffer_backend_metadata.empty()) {
+      rcutils_string_map_t buffer_backend_metadata = rcutils_get_zero_initialized_string_map();
+      rcutils_ret_t rcutils_ret = rcutils_string_map_init(
+        &buffer_backend_metadata,
+        entity_pair.second.buffer_backend_metadata.size(),
+        *allocator);
+      if (RCUTILS_RET_OK != rcutils_ret) {
+        RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
+        rcutils_reset_error();
+        return rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
+      }
+
+      for (const auto & backend_pair : entity_pair.second.buffer_backend_metadata) {
+        rcutils_ret = rcutils_string_map_set(
+          &buffer_backend_metadata,
+          backend_pair.first.c_str(),
+          backend_pair.second.c_str());
+        if (RCUTILS_RET_OK != rcutils_ret) {
+          rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
+          (void)fini_ret;
+          RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
+          rcutils_reset_error();
+          return rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
+        }
+      }
+
+      ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
+        &endpoint_info,
+        &buffer_backend_metadata,
+        allocator);
+      rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
+      (void)fini_ret;
+      if (RMW_RET_OK != ret) {
+        return ret;
+      }
     }
     i++;
   }

--- a/rmw_dds_common/src/graph_cache.cpp
+++ b/rmw_dds_common/src/graph_cache.cpp
@@ -32,10 +32,10 @@
 
 #include "rcutils/strdup.h"
 #include "rcutils/error_handling.h"
-#include "rcutils/types/string_map.h"
 
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/buffer_backend_metadata.hpp"
 #include "rmw/sanity_checks.h"
 #include "rmw/topic_endpoint_info.h"
 #include "rmw/topic_endpoint_info_array.h"
@@ -633,39 +633,17 @@ __get_entities_info_by_topic(
     }
 
     if (!entity_pair.second.buffer_backend_metadata.empty()) {
-      rcutils_string_map_t buffer_backend_metadata = rcutils_get_zero_initialized_string_map();
-      rcutils_ret_t rcutils_ret = rcutils_string_map_init(
-        &buffer_backend_metadata,
-        entity_pair.second.buffer_backend_metadata.size(),
-        *allocator);
-      if (RCUTILS_RET_OK != rcutils_ret) {
-        RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
-        rcutils_reset_error();
-        return rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
-      }
-
-      for (const auto & backend_pair : entity_pair.second.buffer_backend_metadata) {
-        rcutils_ret = rcutils_string_map_set(
-          &buffer_backend_metadata,
-          backend_pair.first.c_str(),
-          backend_pair.second.c_str());
-        if (RCUTILS_RET_OK != rcutils_ret) {
-          rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
-          (void)fini_ret;
-          RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
-          rcutils_reset_error();
-          return rmw_convert_rcutils_ret_to_rmw_ret(rcutils_ret);
+      const std::string buffer_backend_metadata =
+        rmw::impl::cpp::serialize_buffer_backend_metadata(
+          entity_pair.second.buffer_backend_metadata);
+      if (!buffer_backend_metadata.empty()) {
+        ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
+          &endpoint_info,
+          buffer_backend_metadata.c_str(),
+          allocator);
+        if (RMW_RET_OK != ret) {
+          return ret;
         }
-      }
-
-      ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
-        &endpoint_info,
-        &buffer_backend_metadata,
-        allocator);
-      rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
-      (void)fini_ret;
-      if (RMW_RET_OK != ret) {
-        return ret;
       }
     }
     i++;


### PR DESCRIPTION
## Description

Store buffer backend metadata in `rmw_dds_common::GraphCache` and include it when populating topic endpoint info for graph introspection.

This allows DDS-based RMW implementations using the shared graph cache to preserve backend support information discovered from endpoint metadata.

### Is this user-facing behavior change?

Yes. This enables graph introspection consumers to see rosidl buffer backend support information once RMW implementations populate it.

### Did you use Generative AI?

Yes. GPT-5.5 in Cursor was used to help draft changes in this pull request.

### Additional Information

Depending on:
- https://github.com/ros2/rmw/pull/419